### PR TITLE
feat: QMT 行情策略看板 — K线/均线/策略/10s刷新

### DIFF
--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/controller/QmtController.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/controller/QmtController.java
@@ -1,0 +1,68 @@
+package com.deanrobin.aios.dashboard.controller;
+
+import com.deanrobin.aios.dashboard.model.PriceTicker;
+import com.deanrobin.aios.dashboard.repository.PriceTickerRepository;
+import com.deanrobin.aios.dashboard.service.KlineService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * QMT 行情策略看板 REST 接口。
+ *
+ * GET /api/qmt/data?bar=15m
+ * 返回四个币种的当前价格 + 均线指标 + 策略信号。
+ */
+@RestController
+@RequestMapping("/api/qmt")
+@RequiredArgsConstructor
+public class QmtController {
+
+    private static final List<String> SYMBOLS = List.of("BTC", "ETH", "BNB", "SOL");
+    private static final List<String> VALID_BARS =
+            List.of("15m", "1H", "4H", "1D", "1W");
+
+    private final PriceTickerRepository priceRepo;
+    private final KlineService          klineService;
+
+    /**
+     * 主数据接口：价格 + 均线 + 策略。
+     *
+     * @param bar 时间粒度：15m / 1H / 4H / 1D / 1W，默认 15m
+     */
+    @GetMapping("/data")
+    public Map<String, Object> data(
+            @RequestParam(defaultValue = "15m") String bar) {
+
+        // 参数白名单校验
+        if (!VALID_BARS.contains(bar)) bar = "15m";
+
+        // ── 价格（从 DB 读，PriceFetchJob 每 10s 更新）────────────
+        List<PriceTicker> tickers = priceRepo.findAllByOrderBySymbolAsc();
+        List<Map<String, Object>> priceList = tickers.stream().map(p -> {
+            Map<String, Object> m = new LinkedHashMap<>();
+            m.put("symbol",    p.getSymbol());
+            m.put("priceUsd",  p.getPriceUsd());
+            m.put("change24h", p.getChange24h());
+            m.put("volume24h", p.getVolume24h());
+            m.put("updatedAt", p.getUpdatedAt() != null ? p.getUpdatedAt().toString() : null);
+            return m;
+        }).collect(Collectors.toList());
+
+        // ── 均线 + 策略（从 kline_bar 计算）────────────────────
+        Map<String, Map<String, Object>> indicators = new LinkedHashMap<>();
+        for (String symbol : SYMBOLS) {
+            indicators.put(symbol, klineService.analyze(symbol, bar));
+        }
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("tickers",    priceList);
+        result.put("indicators", indicators);
+        result.put("bar",        bar);
+        result.put("validHours", KlineService.validHours(bar));
+        result.put("serverTime", java.time.LocalDateTime.now().toString());
+        return result;
+    }
+}

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/KlineFetchJob.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/KlineFetchJob.java
@@ -1,0 +1,174 @@
+package com.deanrobin.aios.dashboard.job;
+
+import com.deanrobin.aios.dashboard.model.KlineBar;
+import com.deanrobin.aios.dashboard.repository.KlineBarRepository;
+import com.deanrobin.aios.dashboard.service.KlineService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.math.BigDecimal;
+import java.time.*;
+import java.util.*;
+
+/**
+ * K 线数据抓取任务。
+ *
+ * <ul>
+ *   <li>每 30s 拉取最新 5 根 K 线（覆盖进行中的 K 线）</li>
+ *   <li>首次启动如本地数据 < 180 根，自动补录 300 根历史</li>
+ *   <li>00:20 按各 bar 保留策略清理过期数据：
+ *       15m=7天 | 1H=30天 | 4H=180天 | 1D=730天 | 1W=2000天</li>
+ * </ul>
+ *
+ * OKX 公开端点，无需签名：
+ * GET https://www.okx.com/api/v5/market/candles?instId=BTC-USDT&bar=15m&limit=5
+ */
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class KlineFetchJob {
+
+    private static final List<String> SYMBOLS = List.of("BTC", "ETH", "BNB", "SOL");
+    private static final List<String> BARS    = List.of("15m", "1H", "4H", "1D", "1W");
+
+    private static final String BASE_URL = "https://www.okx.com";
+    private static final int    HISTORY_THRESHOLD = 180; // 低于此数量触发批量补录
+    private static final int    BATCH_LIMIT       = 300; // OKX 单次最大返回条数
+
+    private final KlineBarRepository klineRepo;
+    private final WebClient.Builder  webClientBuilder;
+
+    // ──────────────────────────────────────────────────────────────
+    // 启动时补录历史（延迟 15s 避免与价格任务争抢）
+    // ──────────────────────────────────────────────────────────────
+    @Scheduled(initialDelay = 15_000, fixedDelay = Long.MAX_VALUE)
+    public void backfillOnStartup() {
+        log.info("📦 K 线历史补录开始...");
+        WebClient client = webClientBuilder.baseUrl(BASE_URL).build();
+        int saved = 0;
+        for (String symbol : SYMBOLS) {
+            for (String bar : BARS) {
+                long count = klineRepo.countBySymbolAndBar(symbol, bar);
+                if (count < HISTORY_THRESHOLD) {
+                    saved += fetchAndSave(client, symbol, bar, BATCH_LIMIT);
+                    sleepMs(200); // OKX 公开接口限速约 20 次/秒
+                }
+            }
+        }
+        log.info("📦 K 线历史补录完成，共 upsert {} 条", saved);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // 每 30s 拉取最新 5 根（覆盖未收盘 K 线）
+    // ──────────────────────────────────────────────────────────────
+    @Scheduled(initialDelay = 20_000, fixedDelay = 30_000)
+    public void fetchLatest() {
+        WebClient client = webClientBuilder.baseUrl(BASE_URL).build();
+        for (String symbol : SYMBOLS) {
+            for (String bar : BARS) {
+                try {
+                    fetchAndSave(client, symbol, bar, 5);
+                } catch (Exception e) {
+                    log.warn("⚠️ K 线拉取失败 {}/{}: {}", symbol, bar, e.getMessage());
+                }
+                sleepMs(80);
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // 00:20 清理过期 K 线
+    // ──────────────────────────────────────────────────────────────
+    @Scheduled(cron = "0 20 0 * * *")
+    public void cleanupOldKlines() {
+        LocalDateTime now = LocalDateTime.now();
+        Map<String, Integer> retentionDays = Map.of(
+            "15m", 7,
+            "1H",  30,
+            "4H",  180,
+            "1D",  730,
+            "1W",  2000
+        );
+        int total = 0;
+        for (Map.Entry<String, Integer> e : retentionDays.entrySet()) {
+            String bar  = e.getKey();
+            LocalDateTime cutoff = now.minusDays(e.getValue());
+            int deleted = klineRepo.deleteByBarAndOpenTimeBefore(bar, cutoff);
+            if (deleted > 0) {
+                log.info("🗑️ K 线清理 bar={} cutoff={} deleted={}", bar, cutoff.toLocalDate(), deleted);
+            }
+            total += deleted;
+        }
+        log.info("🗑️ K 线清理完成，共删除 {} 条", total);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // 核心拉取方法
+    // ──────────────────────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    private int fetchAndSave(WebClient client, String symbol, String bar, int limit) {
+        String instId = symbol + "-USDT";
+        String url    = "/api/v5/market/candles?instId=" + instId + "&bar=" + bar + "&limit=" + limit;
+
+        Map<?, ?> resp;
+        try {
+            resp = client.get().uri(url).retrieve()
+                    .bodyToMono(Map.class)
+                    .block(Duration.ofSeconds(8));
+        } catch (Exception e) {
+            log.warn("⚠️ OKX candles 超时 {}/{}", symbol, bar);
+            return 0;
+        }
+
+        if (resp == null || !"0".equals(String.valueOf(resp.get("code")))) return 0;
+        Object dataObj = resp.get("data");
+        if (!(dataObj instanceof List<?> dataList) || dataList.isEmpty()) return 0;
+
+        int saved = 0;
+        for (Object rowObj : dataList) {
+            if (!(rowObj instanceof List<?> row) || row.size() < 7) continue;
+            try {
+                long   tsMs      = Long.parseLong(String.valueOf(row.get(0)));
+                LocalDateTime openTime = LocalDateTime.ofInstant(
+                        Instant.ofEpochMilli(tsMs), ZoneId.of("Asia/Shanghai"));
+
+                KlineBar kb = klineRepo.findBySymbolAndBarAndOpenTime(symbol, bar, openTime)
+                        .orElseGet(() -> {
+                            KlineBar n = new KlineBar();
+                            n.setSymbol(symbol);
+                            n.setBar(bar);
+                            n.setOpenTime(openTime);
+                            n.setCreatedAt(LocalDateTime.now());
+                            return n;
+                        });
+
+                kb.setOpenPrice (parseBD(row.get(1)));
+                kb.setHighPrice (parseBD(row.get(2)));
+                kb.setLowPrice  (parseBD(row.get(3)));
+                kb.setClosePrice(parseBD(row.get(4)));
+                kb.setVolume    (parseBD(row.get(5)));
+                kb.setVolumeUsdt(row.size() > 6 ? parseBD(row.get(6)) : null);
+                kb.setConfirmed (row.size() > 8 && "1".equals(String.valueOf(row.get(8))));
+
+                klineRepo.save(kb);
+                saved++;
+            } catch (Exception e) {
+                log.debug("⚠️ K 线行解析失败 {}/{}: {}", symbol, bar, e.getMessage());
+            }
+        }
+        return saved;
+    }
+
+    private static BigDecimal parseBD(Object obj) {
+        if (obj == null) return BigDecimal.ZERO;
+        try { return new BigDecimal(String.valueOf(obj)); } catch (Exception e) { return BigDecimal.ZERO; }
+    }
+
+    private static void sleepMs(long ms) {
+        try { Thread.sleep(ms); } catch (InterruptedException ignored) { Thread.currentThread().interrupt(); }
+    }
+}

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/PriceFetchJob.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/PriceFetchJob.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * 每 30 秒从 OKX 公开市场 API 拉 BTC/ETH/BNB/SOL 价格，写入 price_ticker 表。
+ * 每 10 秒从 OKX 公开市场 API 拉 BTC/ETH/BNB/SOL 价格及 24h 交易量，写入 price_ticker 表。
  * OKX 公开端点无需签名：GET https://www.okx.com/api/v5/market/ticker?instId=BTC-USDT
  */
 @Log4j2
@@ -32,13 +32,13 @@ public class PriceFetchJob {
     private final PriceTickerRepository priceRepo;
     private final WebClient.Builder webClientBuilder;
 
-    @Scheduled(initialDelay = 5000, fixedDelay = 30000)
+    @Scheduled(initialDelay = 5_000, fixedDelay = 10_000)
     public void fetchPrices() {
         WebClient client = webClientBuilder.baseUrl("https://www.okx.com").build();
         int updated = 0;
         for (String[] pair : TARGETS) {
-            String symbol  = pair[0];
-            String instId  = pair[1];
+            String symbol = pair[0];
+            String instId = pair[1];
             try {
                 Map<?, ?> resp = client.get()
                     .uri("/api/v5/market/ticker?instId=" + instId)
@@ -51,8 +51,10 @@ public class PriceFetchJob {
                 if (!(data instanceof List<?> list) || list.isEmpty()) continue;
                 Map<?, ?> tick = (Map<?, ?>) list.get(0);
 
-                BigDecimal price  = parseBD(tick.get("last"));
-                BigDecimal open24 = parseBD(tick.get("open24h"));
+                BigDecimal price   = parseBD(tick.get("last"));
+                BigDecimal open24  = parseBD(tick.get("open24h"));
+                BigDecimal vol24h  = parseBD(tick.get("volCcy24h")); // USDT 成交额
+
                 BigDecimal change24h = null;
                 if (price != null && open24 != null && open24.compareTo(BigDecimal.ZERO) != 0) {
                     change24h = price.subtract(open24)
@@ -66,6 +68,7 @@ public class PriceFetchJob {
                 });
                 pt.setPriceUsd(price);
                 pt.setChange24h(change24h);
+                pt.setVolume24h(vol24h);
                 pt.setUpdatedAt(LocalDateTime.now());
                 priceRepo.save(pt);
                 updated++;

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/model/KlineBar.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/model/KlineBar.java
@@ -1,0 +1,62 @@
+package com.deanrobin.aios.dashboard.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * K 线数据（OHLCV）。
+ * 支持 5 个时间粒度：15m / 1H / 4H / 1D / 1W
+ * 由 KlineFetchJob 每 30s 从 OKX 公开 API 拉取并 upsert。
+ */
+@Data
+@Entity
+@Table(name = "kline_bar",
+       uniqueConstraints = @UniqueConstraint(name = "uk_symbol_bar_time",
+                                             columnNames = {"symbol", "bar", "open_time"}))
+public class KlineBar {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** BTC / ETH / BNB / SOL */
+    @Column(nullable = false, length = 20)
+    private String symbol;
+
+    /** 15m / 1H / 4H / 1D / 1W */
+    @Column(nullable = false, length = 10)
+    private String bar;
+
+    @Column(name = "open_time", nullable = false)
+    private LocalDateTime openTime;
+
+    @Column(name = "open_price",  nullable = false, precision = 30, scale = 8)
+    private BigDecimal openPrice;
+
+    @Column(name = "high_price",  nullable = false, precision = 30, scale = 8)
+    private BigDecimal highPrice;
+
+    @Column(name = "low_price",   nullable = false, precision = 30, scale = 8)
+    private BigDecimal lowPrice;
+
+    @Column(name = "close_price", nullable = false, precision = 30, scale = 8)
+    private BigDecimal closePrice;
+
+    /** 成交量（基础货币，如 BTC 数量） */
+    @Column(nullable = false, precision = 30, scale = 4)
+    private BigDecimal volume;
+
+    /** 成交额（USDT） */
+    @Column(name = "volume_usdt", precision = 30, scale = 4)
+    private BigDecimal volumeUsdt;
+
+    /** 0 = 未收盘（进行中），1 = 已收盘 */
+    @Column(nullable = false, columnDefinition = "TINYINT(1) DEFAULT 0")
+    private boolean confirmed;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+}

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/model/PriceTicker.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/model/PriceTicker.java
@@ -25,6 +25,10 @@ public class PriceTicker {
     @Column(name = "change_24h", precision = 10, scale = 4)
     private BigDecimal change24h;
 
+    /** 24H 交易量（USDT，来自 OKX ticker volCcy24h 字段） */
+    @Column(name = "volume_24h", precision = 30, scale = 4)
+    private BigDecimal volume24h;
+
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 }

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/KlineBarRepository.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/KlineBarRepository.java
@@ -1,0 +1,34 @@
+package com.deanrobin.aios.dashboard.repository;
+
+import com.deanrobin.aios.dashboard.model.KlineBar;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface KlineBarRepository extends JpaRepository<KlineBar, Long> {
+
+    Optional<KlineBar> findBySymbolAndBarAndOpenTime(String symbol, String bar, LocalDateTime openTime);
+
+    /** 按开盘时间倒序，取最近 N 条（用于 MA/EMA 计算） */
+    @Query("SELECT k FROM KlineBar k WHERE k.symbol = :symbol AND k.bar = :bar ORDER BY k.openTime DESC")
+    List<KlineBar> findLatestBars(@Param("symbol") String symbol,
+                                  @Param("bar") String bar,
+                                  Pageable pageable);
+
+    /** 统计某 symbol+bar 的数据条数（判断是否需要批量补录历史） */
+    long countBySymbolAndBar(String symbol, String bar);
+
+    /** 按 bar 类型清理超期数据（00:20 定时任务调用） */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM KlineBar k WHERE k.bar = :bar AND k.openTime < :cutoff")
+    int deleteByBarAndOpenTimeBefore(@Param("bar") String bar,
+                                     @Param("cutoff") LocalDateTime cutoff);
+}

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/KlineService.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/KlineService.java
@@ -1,0 +1,189 @@
+package com.deanrobin.aios.dashboard.service;
+
+import com.deanrobin.aios.dashboard.model.KlineBar;
+import com.deanrobin.aios.dashboard.repository.KlineBarRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * K 线均线计算 + 策略分析服务。
+ * <p>
+ * 均线：
+ *   MA20 / MA120  — 简单移动平均
+ *   EMA144 / EMA169 — 指数移动平均（乘数 k = 2/(n+1)）
+ * <p>
+ * 策略打分（满分 4 分）：
+ *   +1  价格 > MA20（站上短期均线）
+ *   +1  MA20  > MA120（短期均线在长期均线上方，上升趋势）
+ *   +1  EMA144 > EMA169（EMA 多头排列）
+ *   +1  最新 K 线成交量 > 20 期均量 × 1.2（成交量放大）
+ * <p>
+ * 信号：≥3 = 看多 BULL，≤1 = 看空 BEAR，其余 = 中性 NEUTRAL
+ */
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class KlineService {
+
+    // 需要至少加载多少根 K 线来计算指标
+    public static final int LOAD_LIMIT = 220;
+
+    private final KlineBarRepository klineRepo;
+
+    // ──────────────────────────────────────────────────────────────
+    // 公开 API
+    // ──────────────────────────────────────────────────────────────
+
+    /**
+     * 返回指定 symbol + bar 的均线指标 + 策略结果。
+     * 结果 Map 键：ma20, ma120, ema144, ema169, volume, avgVolume20,
+     *              signal, signalScore, reasons, validHours,
+     *              bars（最近 N 根 K 线，用于前端渲染）
+     */
+    public Map<String, Object> analyze(String symbol, String bar) {
+        List<KlineBar> raw = klineRepo.findLatestBars(symbol, bar,
+                PageRequest.of(0, LOAD_LIMIT));
+
+        // 倒序 → 时间正序（旧 → 新）
+        List<KlineBar> bars = new ArrayList<>(raw);
+        Collections.reverse(bars);
+
+        int n = bars.size();
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("symbol", symbol);
+        result.put("bar", bar);
+        result.put("dataCount", n);
+
+        if (n < 20) {
+            result.put("signal", "WAIT");
+            result.put("signalScore", 0);
+            result.put("reasons", List.of("数据不足（需≥20根）"));
+            result.put("validHours", 0);
+            return result;
+        }
+
+        List<Double> closes  = bars.stream().map(k -> k.getClosePrice().doubleValue()).collect(Collectors.toList());
+        List<Double> volumes = bars.stream().map(k -> k.getVolumeUsdt() != null
+                ? k.getVolumeUsdt().doubleValue() : k.getVolume().doubleValue()).collect(Collectors.toList());
+
+        // ── 均线计算 ──────────────────────────────────────────────
+        Double ma20   = sma(closes, 20);
+        Double ma120  = n >= 120 ? sma(closes, 120) : null;
+        Double ema144 = n >= 144 ? ema(closes, 144) : null;
+        Double ema169 = n >= 169 ? ema(closes, 169) : null;
+
+        double currentPrice = closes.get(n - 1);
+
+        // ── 成交量 ──────────────────────────────────────────────
+        double latestVol   = volumes.get(n - 1);
+        double avgVol20    = volumes.subList(Math.max(0, n - 20), n)
+                .stream().mapToDouble(Double::doubleValue).average().orElse(0);
+
+        // ── 策略打分 ──────────────────────────────────────────────
+        int score = 0;
+        List<String> reasons = new ArrayList<>();
+
+        if (ma20 != null && currentPrice > ma20) {
+            score++;
+            reasons.add("价格 > MA20（站上短期均线）");
+        } else if (ma20 != null) {
+            reasons.add("价格 < MA20（跌破短期均线）");
+        }
+
+        if (ma20 != null && ma120 != null) {
+            if (ma20 > ma120) {
+                score++;
+                reasons.add("MA20 > MA120（上升趋势）");
+            } else {
+                reasons.add("MA20 < MA120（下降趋势）");
+            }
+        }
+
+        if (ema144 != null && ema169 != null) {
+            if (ema144 > ema169) {
+                score++;
+                reasons.add("EMA144 > EMA169（EMA 多头排列）");
+            } else {
+                reasons.add("EMA144 < EMA169（EMA 空头排列）");
+            }
+        }
+
+        if (avgVol20 > 0 && latestVol > avgVol20 * 1.2) {
+            score++;
+            reasons.add(String.format("成交量放大（×%.1f 均量）", latestVol / avgVol20));
+        } else if (avgVol20 > 0) {
+            reasons.add(String.format("成交量偏低（×%.1f 均量）", latestVol / avgVol20));
+        }
+
+        String signal;
+        if (score >= 3)      signal = "BULL";
+        else if (score <= 1) signal = "BEAR";
+        else                 signal = "NEUTRAL";
+
+        // ── 填充结果 ──────────────────────────────────────────────
+        result.put("currentPrice", round(currentPrice, 4));
+        result.put("ma20",   ma20   != null ? round(ma20,   4) : null);
+        result.put("ma120",  ma120  != null ? round(ma120,  4) : null);
+        result.put("ema144", ema144 != null ? round(ema144, 4) : null);
+        result.put("ema169", ema169 != null ? round(ema169, 4) : null);
+        result.put("volume",      round(latestVol, 2));
+        result.put("avgVolume20", round(avgVol20,  2));
+        result.put("signal",      signal);
+        result.put("signalScore", score);
+        result.put("reasons",     reasons);
+        result.put("validHours",  validHours(bar));
+        result.put("openTime",    bars.get(n - 1).getOpenTime());
+
+        return result;
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // 私有工具方法
+    // ──────────────────────────────────────────────────────────────
+
+    /** 简单移动平均（取最后 period 个数） */
+    private Double sma(List<Double> series, int period) {
+        int n = series.size();
+        if (n < period) return null;
+        return series.subList(n - period, n).stream()
+                .mapToDouble(Double::doubleValue).average().orElse(0);
+    }
+
+    /**
+     * 指数移动平均（EMA）。
+     * 从第一个数据点开始迭代，数据越多结果越准（"热身"效应随数据增多而消退）。
+     * k = 2 / (period + 1)
+     */
+    private Double ema(List<Double> series, int period) {
+        if (series.isEmpty()) return null;
+        double k = 2.0 / (period + 1);
+        double emaVal = series.get(0);
+        for (int i = 1; i < series.size(); i++) {
+            emaVal = series.get(i) * k + emaVal * (1 - k);
+        }
+        return emaVal;
+    }
+
+    /** 不同 bar 对应的策略信号有效期（小时） */
+    public static int validHours(String bar) {
+        return switch (bar) {
+            case "15m" -> 4;
+            case "1H"  -> 24;
+            case "4H"  -> 72;   // 3 天
+            case "1D"  -> 168;  // 7 天
+            case "1W"  -> 720;  // 30 天
+            default    -> 24;
+        };
+    }
+
+    private static double round(double v, int scale) {
+        return BigDecimal.valueOf(v).setScale(scale, RoundingMode.HALF_UP).doubleValue();
+    }
+}

--- a/dashboard/src/main/resources/templates/qmt.html
+++ b/dashboard/src/main/resources/templates/qmt.html
@@ -3,11 +3,412 @@
       th:replace="~{layout :: page('QMT', ~{::section})}">
 <body><section>
 
-<div style="padding:60px 20px;text-align:center;color:var(--t3);">
-    <div style="font-size:2.8rem;margin-bottom:16px;">🤖</div>
-    <div style="font-size:1.1rem;font-weight:600;color:var(--t2);margin-bottom:8px;">QMT</div>
-    <div style="font-size:.875rem;">功能建设中，敬请期待…</div>
+<style>
+/* ── QMT 专属样式 ──────────────────────────────────────────── */
+.qmt-wrap { padding: 22px 4px; }
+
+/* 价格卡片行 */
+.price-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 14px;
+    margin-bottom: 20px;
+}
+@media (max-width: 900px) { .price-grid { grid-template-columns: repeat(2, 1fr); } }
+
+.price-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 18px 20px 14px;
+    box-shadow: var(--sh-0);
+    transition: box-shadow .2s, transform .2s;
+    position: relative; overflow: hidden;
+}
+.price-card:hover { box-shadow: var(--sh-2); transform: translateY(-2px); }
+.price-card::before {
+    content: ''; position: absolute;
+    top: 0; left: 0; right: 0; height: 3px;
+    background: var(--pc-accent, var(--blue));
+}
+.pc-btc { --pc-accent: #f7931a; }
+.pc-eth { --pc-accent: #627eea; }
+.pc-bnb { --pc-accent: #f3ba2f; }
+.pc-sol { --pc-accent: #9945ff; }
+
+.pc-sym  { font-size: .75rem; font-weight: 700; color: var(--t3); letter-spacing: 1px; margin-bottom: 6px; }
+.pc-price { font-size: 1.55rem; font-weight: 800; color: var(--t1); font-family: 'JetBrains Mono'; line-height: 1.15; }
+.pc-change { font-size: .82rem; font-weight: 700; margin-top: 3px; }
+.pc-vol { font-size: .72rem; color: var(--t3); margin-top: 6px; }
+.pc-vol span { color: var(--t2); font-weight: 600; }
+.pc-updated { font-size: .65rem; color: var(--t3); margin-top: 4px; }
+
+/* 均线卡片 */
+.ma-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    box-shadow: var(--sh-0);
+    margin-bottom: 16px;
+    overflow: hidden;
+}
+.ma-card-header {
+    background: #fafbff;
+    border-bottom: 1px solid var(--border);
+    padding: 13px 20px;
+    display: flex; align-items: center; justify-content: space-between;
+}
+.ma-card-title { font-weight: 700; font-size: .92rem; color: var(--t1); display: flex; align-items: center; gap: 8px; }
+.ma-card-body { overflow-x: auto; }
+
+/* 策略信号卡片 */
+.sig-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 14px;
+    margin-bottom: 20px;
+}
+@media (max-width: 900px) { .sig-grid { grid-template-columns: repeat(2, 1fr); } }
+
+.sig-card {
+    background: var(--bg-card);
+    border: 2px solid var(--border);
+    border-radius: 14px;
+    padding: 16px 18px;
+    box-shadow: var(--sh-0);
+    transition: all .2s;
+}
+.sig-card.bull { border-color: var(--green-b); background: var(--green-l); }
+.sig-card.bear { border-color: var(--red-b);   background: var(--red-l);   }
+.sig-card.neutral { border-color: var(--yellow-b); background: var(--yellow-l); }
+.sig-card.wait { border-color: var(--border); }
+
+.sig-sym   { font-size: .72rem; font-weight: 700; color: var(--t3); letter-spacing: 1px; margin-bottom: 6px; }
+.sig-label { font-size: 1.3rem; font-weight: 800; margin-bottom: 4px; }
+.sig-score { font-size: .78rem; color: var(--t2); margin-bottom: 8px; }
+.sig-validity { font-size: .7rem; color: var(--t3); }
+.sig-reasons { margin-top: 8px; }
+.sig-reason-item {
+    font-size: .7rem; color: var(--t2);
+    padding: 2px 0; display: flex; align-items: flex-start; gap: 4px;
+}
+.sig-reason-item::before { content: '·'; flex-shrink: 0; }
+
+/* Tab 控件 */
+.tf-tabs {
+    display: inline-flex; gap: 3px;
+    background: #f1f5ff;
+    border: 1px solid var(--border);
+    border-radius: 10px; padding: 3px;
+    margin-bottom: 18px;
+}
+.tf-tab {
+    padding: 6px 18px; border-radius: 7px;
+    font-size: .82rem; font-weight: 500; color: var(--t2);
+    cursor: pointer; transition: all .15s; white-space: nowrap;
+    user-select: none;
+}
+.tf-tab:hover:not(.active) { color: var(--blue); background: rgba(59,130,246,.08); }
+.tf-tab.active {
+    background: #fff; color: var(--blue); font-weight: 700;
+    box-shadow: 0 1px 5px rgba(15,23,42,.12);
+}
+
+/* 状态栏 */
+.qmt-status {
+    display: flex; align-items: center; gap: 16px;
+    font-size: .75rem; color: var(--t3);
+    margin-bottom: 18px; flex-wrap: wrap;
+}
+.qmt-status .pulse-dot { margin-right: 2px; }
+.countdown-bar {
+    height: 3px; background: var(--border);
+    border-radius: 2px; overflow: hidden;
+    width: 80px; display: inline-block; vertical-align: middle; margin: 0 4px;
+}
+.countdown-fill {
+    height: 100%; background: linear-gradient(90deg, var(--blue), var(--cyan));
+    border-radius: 2px; transition: width .5s linear;
+}
+
+/* MA 数值格子 */
+.ma-val { font-family: 'JetBrains Mono'; font-size: .84rem; font-weight: 600; }
+.ma-above { color: var(--green); }
+.ma-below { color: var(--red); }
+
+/* 成交量格式 */
+.vol-num { font-family: 'JetBrains Mono'; font-size: .82rem; }
+
+/* 空数据提示 */
+.ma-empty { text-align: center; color: var(--t3); padding: 24px; font-size: .85rem; }
+</style>
+
+<!-- 状态栏 -->
+<div class="qmt-status">
+    <span><span class="pulse-dot"></span> 实时行情</span>
+    <span>🔄 <span id="countdown-text">10</span>s 后刷新
+        <span class="countdown-bar"><span class="countdown-fill" id="cbar" style="width:100%"></span></span>
+    </span>
+    <span id="last-updated">--</span>
+    <span id="bar-label" style="color:var(--blue);font-weight:600;"></span>
+    <span id="valid-hint" style="color:var(--t2);"></span>
 </div>
+
+<!-- 价格卡片 -->
+<div class="price-grid" id="price-grid">
+    <div class="price-card pc-btc"><div class="pc-sym">BTC</div><div class="pc-price" id="p-BTC">--</div><div class="pc-change" id="c-BTC">--</div><div class="pc-vol">24h Vol: <span id="v-BTC">--</span></div><div class="pc-updated" id="u-BTC"></div></div>
+    <div class="price-card pc-eth"><div class="pc-sym">ETH</div><div class="pc-price" id="p-ETH">--</div><div class="pc-change" id="c-ETH">--</div><div class="pc-vol">24h Vol: <span id="v-ETH">--</span></div><div class="pc-updated" id="u-ETH"></div></div>
+    <div class="price-card pc-bnb"><div class="pc-sym">BNB</div><div class="pc-price" id="p-BNB">--</div><div class="pc-change" id="c-BNB">--</div><div class="pc-vol">24h Vol: <span id="v-BNB">--</span></div><div class="pc-updated" id="u-BNB"></div></div>
+    <div class="price-card pc-sol"><div class="pc-sym">SOL</div><div class="pc-price" id="p-SOL">--</div><div class="pc-change" id="c-SOL">--</div><div class="pc-vol">24h Vol: <span id="v-SOL">--</span></div><div class="pc-updated" id="u-SOL"></div></div>
+</div>
+
+<!-- 时间周期 Tab -->
+<div class="tf-tabs">
+    <div class="tf-tab active" data-bar="15m">15min</div>
+    <div class="tf-tab" data-bar="1H">1H</div>
+    <div class="tf-tab" data-bar="4H">4H</div>
+    <div class="tf-tab" data-bar="1D">1D</div>
+    <div class="tf-tab" data-bar="1W">7D</div>
+</div>
+
+<!-- 策略信号卡片 -->
+<div class="sig-grid" id="sig-grid">
+    <div class="sig-card" id="sig-BTC"><div class="sig-sym">BTC</div><div class="sig-label">--</div><div class="sig-score">--</div><div class="sig-validity">--</div><div class="sig-reasons"></div></div>
+    <div class="sig-card" id="sig-ETH"><div class="sig-sym">ETH</div><div class="sig-label">--</div><div class="sig-score">--</div><div class="sig-validity">--</div><div class="sig-reasons"></div></div>
+    <div class="sig-card" id="sig-BNB"><div class="sig-sym">BNB</div><div class="sig-label">--</div><div class="sig-score">--</div><div class="sig-validity">--</div><div class="sig-reasons"></div></div>
+    <div class="sig-card" id="sig-SOL"><div class="sig-sym">SOL</div><div class="sig-label">--</div><div class="sig-score">--</div><div class="sig-validity">--</div><div class="sig-reasons"></div></div>
+</div>
+
+<!-- 均线数值表 -->
+<div class="ma-card">
+    <div class="ma-card-header">
+        <div class="ma-card-title">📐 均线指标 <span id="ma-bar-badge" class="tag-blue">15min</span></div>
+        <div style="font-size:.72rem;color:var(--t3);">MA20 / MA120 = 简单均线 &nbsp;|&nbsp; EMA144 / EMA169 = 指数均线</div>
+    </div>
+    <div class="ma-card-body">
+        <table class="table" id="ma-table">
+            <thead>
+                <tr>
+                    <th>币种</th>
+                    <th>当前价格</th>
+                    <th>MA20</th>
+                    <th>MA120</th>
+                    <th>EMA144</th>
+                    <th>EMA169</th>
+                    <th>成交量</th>
+                    <th>均量(20)</th>
+                    <th>量比</th>
+                </tr>
+            </thead>
+            <tbody id="ma-tbody">
+                <tr><td colspan="9" class="ma-empty">加载中...</td></tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<script>
+(function () {
+    const REFRESH_INTERVAL = 10; // 秒
+    const SYMBOLS = ['BTC', 'ETH', 'BNB', 'SOL'];
+
+    let currentBar = '15m';
+    let refreshTimer = null;
+    let countdown = REFRESH_INTERVAL;
+
+    // ── Tab 切换 ────────────────────────────────────────────────
+    document.querySelectorAll('.tf-tab').forEach(tab => {
+        tab.addEventListener('click', () => {
+            document.querySelectorAll('.tf-tab').forEach(t => t.classList.remove('active'));
+            tab.classList.add('active');
+            currentBar = tab.dataset.bar;
+            loadData();
+        });
+    });
+
+    // ── 倒计时 & 自动刷新 ──────────────────────────────────────
+    function startCountdown() {
+        clearInterval(refreshTimer);
+        countdown = REFRESH_INTERVAL;
+        refreshTimer = setInterval(() => {
+            countdown--;
+            document.getElementById('countdown-text').textContent = countdown;
+            const pct = (countdown / REFRESH_INTERVAL * 100).toFixed(0);
+            document.getElementById('cbar').style.width = pct + '%';
+            if (countdown <= 0) {
+                loadData();
+                countdown = REFRESH_INTERVAL;
+            }
+        }, 1000);
+    }
+
+    // ── 主数据加载 ──────────────────────────────────────────────
+    function loadData() {
+        fetch('/api/qmt/data?bar=' + currentBar)
+            .then(r => r.json())
+            .then(data => {
+                renderPrices(data.tickers || []);
+                renderSignals(data.indicators || {}, data.validHours || 0, currentBar);
+                renderMaTable(data.indicators || {}, currentBar);
+                document.getElementById('last-updated').textContent =
+                    '更新于 ' + new Date().toLocaleTimeString('zh-CN');
+                const barLabels = {'15m':'15min','1H':'1H','4H':'4H','1D':'1D','1W':'7D'};
+                document.getElementById('bar-label').textContent = '周期: ' + (barLabels[currentBar] || currentBar);
+                const vh = data.validHours || 0;
+                document.getElementById('valid-hint').textContent =
+                    '信号有效期: ' + fmtHours(vh);
+            })
+            .catch(e => console.warn('QMT data load error', e));
+    }
+
+    // ── 价格渲染 ────────────────────────────────────────────────
+    function renderPrices(tickers) {
+        tickers.forEach(t => {
+            const sym = t.symbol;
+            const price = parseFloat(t.priceUsd) || 0;
+            const chg   = parseFloat(t.change24h) || 0;
+            const vol   = parseFloat(t.volume24h) || 0;
+
+            const pe = document.getElementById('p-' + sym);
+            if (pe) pe.textContent = fmtPrice(price, sym);
+
+            const ce = document.getElementById('c-' + sym);
+            if (ce) {
+                ce.textContent = (chg >= 0 ? '▲ +' : '▼ ') + chg.toFixed(2) + '%';
+                ce.className   = 'pc-change ' + (chg >= 0 ? 'up' : 'dn');
+            }
+
+            const ve = document.getElementById('v-' + sym);
+            if (ve) ve.textContent = vol > 0 ? fmtVol(vol) : '--';
+
+            const ue = document.getElementById('u-' + sym);
+            if (ue && t.updatedAt) ue.textContent = '更新: ' + t.updatedAt.substring(11, 19);
+        });
+    }
+
+    // ── 策略信号卡渲染 ──────────────────────────────────────────
+    function renderSignals(indicators, validHours, bar) {
+        SYMBOLS.forEach(sym => {
+            const ind = indicators[sym];
+            const card = document.getElementById('sig-' + sym);
+            if (!card) return;
+
+            if (!ind || ind.signal === 'WAIT') {
+                card.className = 'sig-card wait';
+                card.querySelector('.sig-label').textContent  = '⏳ 等待数据';
+                card.querySelector('.sig-score').textContent  = '数据不足，等待 K 线积累';
+                card.querySelector('.sig-validity').textContent = '';
+                card.querySelector('.sig-reasons').innerHTML  = '';
+                return;
+            }
+
+            const sig   = ind.signal || 'NEUTRAL';
+            const score = ind.signalScore || 0;
+            const reasons = ind.reasons || [];
+
+            card.className = 'sig-card ' + sig.toLowerCase();
+            card.querySelector('.sig-label').textContent =
+                sig === 'BULL'    ? '📈 看多 BULL'   :
+                sig === 'BEAR'    ? '📉 看空 BEAR'   :
+                                    '➡ 中性 NEUTRAL';
+            card.querySelector('.sig-score').textContent =
+                '综合评分 ' + score + ' / 4 分';
+            card.querySelector('.sig-validity').textContent =
+                '有效期约 ' + fmtHours(validHours);
+
+            const reasonsEl = card.querySelector('.sig-reasons');
+            reasonsEl.innerHTML = reasons.map(r =>
+                `<div class="sig-reason-item">${escHtml(r)}</div>`
+            ).join('');
+        });
+    }
+
+    // ── 均线表渲染 ──────────────────────────────────────────────
+    function renderMaTable(indicators, bar) {
+        const barLabels = {'15m':'15min','1H':'1H','4H':'4H','1D':'1D','1W':'7D'};
+        document.getElementById('ma-bar-badge').textContent = barLabels[bar] || bar;
+
+        const tbody = document.getElementById('ma-tbody');
+        if (!tbody) return;
+
+        const rows = SYMBOLS.map(sym => {
+            const ind = indicators[sym];
+            if (!ind || ind.signal === 'WAIT') {
+                return `<tr>
+                    <td><strong>${sym}</strong></td>
+                    <td colspan="8" style="color:var(--t3);font-size:.8rem;">数据积累中…</td>
+                </tr>`;
+            }
+
+            const price   = ind.currentPrice;
+            const ma20    = ind.ma20;
+            const ma120   = ind.ma120;
+            const ema144  = ind.ema144;
+            const ema169  = ind.ema169;
+            const vol     = ind.volume;
+            const avgVol  = ind.avgVolume20;
+            const volRatio = avgVol > 0 ? (vol / avgVol).toFixed(2) : '--';
+
+            const priceClass  = ma20 != null ? (price > ma20 ? 'ma-above' : 'ma-below') : '';
+            const ma20Class   = (ma20 != null && ma120 != null) ? (ma20 > ma120 ? 'ma-above' : 'ma-below') : '';
+            const ma120Class  = '';
+            const ema144Class = (ema144 != null && ema169 != null) ? (ema144 > ema169 ? 'ma-above' : 'ma-below') : '';
+            const ema169Class = '';
+            const volClass    = (avgVol > 0 && vol > avgVol * 1.2) ? 'ma-above' : '';
+
+            return `<tr>
+                <td><strong>${sym}</strong></td>
+                <td class="ma-val ${priceClass}">${fmtPrice(price, sym)}</td>
+                <td class="ma-val ${ma20Class}">${ma20 != null ? fmtPrice(ma20, sym) : '<span style="color:var(--t3)">—</span>'}</td>
+                <td class="ma-val ${ma120Class}">${ma120 != null ? fmtPrice(ma120, sym) : '<span style="color:var(--t3)">—</span>'}</td>
+                <td class="ma-val ${ema144Class}">${ema144 != null ? fmtPrice(ema144, sym) : '<span style="color:var(--t3)">—</span>'}</td>
+                <td class="ma-val ${ema169Class}">${ema169 != null ? fmtPrice(ema169, sym) : '<span style="color:var(--t3)">—</span>'}</td>
+                <td class="vol-num ${volClass}">${fmtVol(vol)}</td>
+                <td class="vol-num">${fmtVol(avgVol)}</td>
+                <td class="ma-val ${volClass}">${volRatio}×</td>
+            </tr>`;
+        });
+
+        tbody.innerHTML = rows.join('');
+    }
+
+    // ── 格式化工具 ──────────────────────────────────────────────
+    function fmtPrice(v, sym) {
+        const n = parseFloat(v) || 0;
+        if (sym === 'BTC') return '$' + n.toLocaleString('en-US', {minimumFractionDigits: 0, maximumFractionDigits: 0});
+        if (n >= 1000) return '$' + n.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+        if (n >= 10)   return '$' + n.toFixed(3);
+        if (n >= 1)    return '$' + n.toFixed(4);
+        return '$' + n.toFixed(6);
+    }
+
+    function fmtVol(v) {
+        const n = parseFloat(v) || 0;
+        if (n <= 0) return '--';
+        if (n >= 1e9) return '$' + (n / 1e9).toFixed(2) + 'B';
+        if (n >= 1e6) return '$' + (n / 1e6).toFixed(2) + 'M';
+        if (n >= 1e3) return '$' + (n / 1e3).toFixed(1) + 'K';
+        return '$' + n.toFixed(2);
+    }
+
+    function fmtHours(h) {
+        if (!h) return '—';
+        if (h >= 720) return Math.round(h / 720) + ' 个月';
+        if (h >= 168) return Math.round(h / 168) + ' 周';
+        if (h >= 24)  return Math.round(h / 24) + ' 天';
+        return h + ' 小时';
+    }
+
+    function escHtml(s) {
+        return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    }
+
+    // ── 启动 ───────────────────────────────────────────────────
+    loadData();
+    startCountdown();
+
+})();
+</script>
 
 </section></body>
 </html>

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -93,3 +93,30 @@ CREATE TABLE IF NOT EXISTS perp_funding_rate (
     INDEX idx_exchange_symbol (exchange, symbol),
     INDEX idx_fetched_at (fetched_at)
 );
+
+-- ── 价格实时表（补充 24h 交易量）────────────────────────────────────
+-- 已有 price_ticker 表，补充 volume_24h 字段（如未执行过则运行）
+ALTER TABLE price_ticker
+    ADD COLUMN IF NOT EXISTS volume_24h DECIMAL(30, 4) COMMENT '24h 交易量（计价货币 USDT）';
+
+-- ── K 线历史表 ──────────────────────────────────────────────────────
+-- 存储 BTC/ETH/BNB/SOL 各时间周期的 K 线数据，供均线和策略计算使用
+-- 清理策略（00:20 执行）：
+--   15m → 保留 7 天；1H → 30 天；4H → 180 天；1D → 730 天；1W → 2000 天
+CREATE TABLE IF NOT EXISTS kline_bar (
+    id           BIGINT PRIMARY KEY AUTO_INCREMENT,
+    symbol       VARCHAR(20)   NOT NULL COMMENT 'BTC / ETH / BNB / SOL',
+    bar          VARCHAR(10)   NOT NULL COMMENT '15m / 1H / 4H / 1D / 1W',
+    open_time    DATETIME      NOT NULL COMMENT 'K 线开盘时间',
+    open_price   DECIMAL(30,8) NOT NULL,
+    high_price   DECIMAL(30,8) NOT NULL,
+    low_price    DECIMAL(30,8) NOT NULL,
+    close_price  DECIMAL(30,8) NOT NULL,
+    volume       DECIMAL(30,4) NOT NULL COMMENT '成交量（基础货币）',
+    volume_usdt  DECIMAL(30,4)          COMMENT '成交量（USDT）',
+    confirmed    TINYINT(1)    DEFAULT 0 COMMENT '0=未收盘 1=已收盘',
+    created_at   DATETIME      DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_symbol_bar_time (symbol, bar, open_time),
+    INDEX idx_symbol_bar (symbol, bar),
+    INDEX idx_open_time  (open_time)
+);


### PR DESCRIPTION
## 新功能

### 数据层
- `kline_bar` 新表：存储 BTC/ETH/BNB/SOL 五个周期(15m/1H/4H/1D/1W)的 OHLCV K线
- `price_ticker` 补充 `volume_24h` 字段（OKX volCcy24h）
- `db/schema.sql` 追加 ALTER TABLE + CREATE TABLE

### 后端
- `KlineBar` 实体 + `KlineBarRepository`（含 @Modifying 清理方法）
- `KlineService`：MA20 / MA120 / EMA144 / EMA169 计算 + 策略打分（4分制）
  - ≥3分=BULL / ≤1分=BEAR / 其余=NEUTRAL
  - 策略维度：价格位置、MA趋势、EMA排列、成交量放大
- `KlineFetchJob`：
  - 启动后批量补录历史（<180根时拉300根）
  - 每30s upsert最新5根K线（含未收盘更新）
  - 每天00:20 按保留期清理：15m=7天 | 1H=30天 | 4H=180天 | 1D=730天 | 1W=2000天
- `QmtController` (`GET /api/qmt/data?bar=15m`)：返回价格+均线+策略 JSON
- `PriceFetchJob` 刷新频率 30s→10s，补存 volume_24h

### 前端 qmt.html（全新）
- 四个价格卡片：价格、24h涨跌幅、24h成交额，10s自动刷新+倒计时进度条
- 时间周期 Tab：15min / 1H / 4H / 1D / 7D（对应 OKX bar=1W）
- 策略信号卡：BULL🟢 / BEAR🔴 / NEUTRAL🟡，含评分与信号有效期
- 均线数值表：当前价、MA20、MA120、EMA144、EMA169、成交量、均量(20)、量比

https://claude.ai/code/session_01PvZ1bcExuLwj3i5T5SJpBv