### PR TITLE
fix: OKX BTC/ETH资金费率 + QMT状态提示

### DIFF
--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/controller/QmtController.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/controller/QmtController.java
@@ -1,6 +1,7 @@
 package com.deanrobin.aios.dashboard.controller;
 
 import com.deanrobin.aios.dashboard.model.PriceTicker;
+import com.deanrobin.aios.dashboard.repository.KlineBarRepository;
 import com.deanrobin.aios.dashboard.repository.PriceTickerRepository;
 import com.deanrobin.aios.dashboard.service.KlineService;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ public class QmtController {
             List.of("15m", "1H", "4H", "1D", "1W");
 
     private final PriceTickerRepository priceRepo;
+    private final KlineBarRepository    klineRepo;
     private final KlineService          klineService;
 
     /**
@@ -63,6 +65,38 @@ public class QmtController {
         result.put("bar",        bar);
         result.put("validHours", KlineService.validHours(bar));
         result.put("serverTime", java.time.LocalDateTime.now().toString());
+        return result;
+    }
+
+    /**
+     * GET /api/qmt/status
+     * 返回 K 线数据积累情况，供页面状态栏展示。
+     */
+    @GetMapping("/status")
+    public Map<String, Object> status() {
+        Map<String, Object> result = new LinkedHashMap<>();
+        // 各 symbol × bar 的 K 线条数
+        Map<String, Object> counts = new LinkedHashMap<>();
+        long totalBars = 0;
+        for (String symbol : SYMBOLS) {
+            Map<String, Long> barCounts = new LinkedHashMap<>();
+            for (String bar : VALID_BARS) {
+                long cnt = klineRepo.countBySymbolAndBar(symbol, bar);
+                barCounts.put(bar, cnt);
+                totalBars += cnt;
+            }
+            counts.put(symbol, barCounts);
+        }
+        // 价格最后更新时间
+        String priceUpdated = priceRepo.findBySymbol("BTC")
+                .map(p -> p.getUpdatedAt() != null ? p.getUpdatedAt().toString() : null)
+                .orElse(null);
+
+        result.put("totalKlineBars",  totalBars);
+        result.put("klineReady",      totalBars >= 80); // 至少有一些 15m 数据
+        result.put("klineCounts",     counts);
+        result.put("priceUpdatedAt",  priceUpdated);
+        result.put("serverTime",      java.time.LocalDateTime.now().toString());
         return result;
     }
 }

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/OkxPerpJob.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/OkxPerpJob.java
@@ -53,10 +53,57 @@ public class OkxPerpJob {
     /** 全量资金费率任务防并发重入 */
     private final AtomicBoolean rateAllRunning = new AtomicBoolean(false);
 
+    /** 优先关注的 OKX 核心合约（USDT本位）—— 启动 5s 后立即写库并打上 isWatched */
+    private static final List<String[]> KEY_CONTRACTS = List.of(
+        new String[]{"BTC-USDT-SWAP", "BTC", "USDT"},
+        new String[]{"ETH-USDT-SWAP", "ETH", "USDT"},
+        new String[]{"BNB-USDT-SWAP", "BNB", "USDT"},
+        new String[]{"SOL-USDT-SWAP", "SOL", "USDT"}
+    );
+
     @PostConstruct
     public void init() {
         ThreadMXBean tmx = ManagementFactory.getThreadMXBean();
         log.info("✅ OkxPerpJob 初始化完成 | DELAY_MS={} | JVM线程数={}", DELAY_MS, tmx.getThreadCount());
+    }
+
+    /**
+     * 启动 5s 后立即对 BTC/ETH/BNB/SOL USDT 永续合约做：
+     *   1. upsert perp_instrument（确保记录存在 + isWatched=true）
+     *   2. 立刻拉取并写入 latestFundingRate
+     * 之后 fetchWatchedRates()（每 1 min）会持续刷新这几个合约。
+     */
+    @Scheduled(initialDelay = 5_000, fixedDelay = Long.MAX_VALUE)
+    public void seedKeyInstruments() {
+        log.info("⭐ OKX 核心合约初始化（seed）开始");
+        LocalDateTime now = LocalDateTime.now();
+        for (String[] kc : KEY_CONTRACTS) {
+            String instId = kc[0], base = kc[1], quote = kc[2];
+            try {
+                PerpInstrument pi = instrumentRepo.findByExchangeAndSymbol(EXCHANGE, instId)
+                        .orElseGet(() -> {
+                            PerpInstrument n = new PerpInstrument();
+                            n.setExchange(EXCHANGE);
+                            n.setSymbol(instId);
+                            n.setFirstSeenAt(now);
+                            return n;
+                        });
+                pi.setBaseCurrency(base);
+                pi.setQuoteCurrency(quote);
+                pi.setIsActive(true);
+                pi.setIsWatched(true);   // 标记关注 → fetchWatchedRates 每分钟刷新
+                pi.setLastSeenAt(now);
+                instrumentRepo.save(pi);
+
+                // 立刻拉一次费率
+                fetchAndSave(pi, now);
+                log.info("⭐ OKX seed {} 完成", instId);
+            } catch (Exception e) {
+                log.warn("⚠️ OKX seed {} 失败: {}", instId, e.getMessage());
+            }
+            sleepMs(300);
+        }
+        log.info("⭐ OKX 核心合约初始化完成");
     }
 
     // ═══ 品种同步（每 5 min，initialDelay 10s）═══════════════════════
@@ -228,5 +275,9 @@ public class OkxPerpJob {
     private BigDecimal parseBD(Object obj) {
         if (obj == null) return null;
         try { return new BigDecimal(String.valueOf(obj)); } catch (Exception e) { return null; }
+    }
+
+    private static void sleepMs(long ms) {
+        try { Thread.sleep(ms); } catch (InterruptedException ie) { Thread.currentThread().interrupt(); }
     }
 }

--- a/dashboard/src/main/resources/templates/qmt.html
+++ b/dashboard/src/main/resources/templates/qmt.html
@@ -154,6 +154,16 @@
     <span id="valid-hint" style="color:var(--t2);"></span>
 </div>
 
+<!-- K线积累状态提示（首次部署时可见，数据就绪后自动隐藏） -->
+<div id="kline-status-bar" style="display:none;
+     background:var(--yellow-l);border:1px solid var(--yellow-b);
+     border-radius:10px;padding:10px 16px;margin-bottom:16px;
+     font-size:.8rem;color:var(--t1);align-items:center;gap:10px;flex-wrap:wrap;">
+    <span style="font-size:1rem">⏳</span>
+    <span id="kline-status-text">K 线历史数据积累中，首次启动约需 1-2 分钟完成补录…</span>
+    <span id="kline-bar-counts" style="color:var(--t3);font-family:'JetBrains Mono';font-size:.72rem;margin-left:auto;"></span>
+</div>
+
 <!-- 价格卡片 -->
 <div class="price-grid" id="price-grid">
     <div class="price-card pc-btc"><div class="pc-sym">BTC</div><div class="pc-price" id="p-BTC">--</div><div class="pc-change" id="c-BTC">--</div><div class="pc-vol">24h Vol: <span id="v-BTC">--</span></div><div class="pc-updated" id="u-BTC"></div></div>
@@ -403,9 +413,37 @@
         return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
     }
 
+    // ── K线状态检查 ──────────────────────────────────────────────
+    function loadStatus() {
+        fetch('/api/qmt/status')
+            .then(r => r.json())
+            .then(s => {
+                const bar = document.getElementById('kline-status-bar');
+                const txt = document.getElementById('kline-status-text');
+                const cnt = document.getElementById('kline-bar-counts');
+                if (!bar) return;
+                const total = s.totalKlineBars || 0;
+                if (total === 0) {
+                    bar.style.display = 'flex';
+                    if (txt) txt.textContent = '⚠️ K 线表为空 — 请确认已执行 db/schema.sql 中的 DDL，并等待 KlineFetchJob 补录数据（启动约 15s 后开始）';
+                    if (cnt) cnt.textContent = '0 条';
+                } else if (!s.klineReady) {
+                    bar.style.display = 'flex';
+                    if (txt) txt.textContent = '⏳ K 线数据积累中… 等待均线指标就绪（需至少 20 根 K 线）';
+                    if (cnt) cnt.textContent = total + ' 条';
+                } else {
+                    bar.style.display = 'none'; // 数据就绪，隐藏提示
+                }
+            })
+            .catch(() => {});
+    }
+
     // ── 启动 ───────────────────────────────────────────────────
+    loadStatus();
     loadData();
     startCountdown();
+    // 每30s刷一次状态（直到数据就绪）
+    setInterval(loadStatus, 30_000);
 
 })();
 </script>


### PR DESCRIPTION
## OKX 资金费率 (OkxPerpJob)
- 新增 seedKeyInstruments()：启动 5s 后立即 upsert BTC/ETH/BNB/SOL USDT 永续合约到 perp_instrument，并立刻拉取资金费率写入 latestFundingRate
- 同时将这4个合约标记为 isWatched=true，由 fetchWatchedRates(每1min)持续刷新
- 不再依赖 fetchAllRates(全量~2.5min) 才能看到核心币种费率

## QMT 状态提示 (QmtController + qmt.html)
- 新增 GET /api/qmt/status：返回各 symbol/bar K线条数 + klineReady 标志
- QMT 页面新增黄色状态横幅：
  - K线表为空 → 提示执行 DDL
  - 数据积累中 → 显示当前条数
  - 就绪 → 自动隐藏
- 每30s刷新一次状态，直到数据就绪

https://claude.ai/code/session_01PvZ1bcExuLwj3i5T5SJpBv