### PR TITLE
feat: 链上持仓监控 (OnchainHolder) 完整实现

### DIFF
--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/controller/OnchainHolderController.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/controller/OnchainHolderController.java
@@ -1,0 +1,152 @@
+package com.deanrobin.aios.dashboard.controller;
+
+import com.deanrobin.aios.dashboard.model.OnchainWatch;
+import com.deanrobin.aios.dashboard.repository.OnchainWatchRepository;
+import com.deanrobin.aios.dashboard.service.OnchainHolderService;
+import com.deanrobin.aios.dashboard.service.OnchainRpcClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.ui.Model;
+
+import java.math.BigDecimal;
+import java.util.*;
+
+/**
+ * 链上持仓监控 Controller。
+ *
+ * <pre>
+ * GET  /onchain-holder               页面
+ * GET  /api/onchain-holder/list      监控任务列表
+ * POST /api/onchain-holder/add       新增监控任务
+ * DELETE /api/onchain-holder/{id}    删除监控任务
+ * PATCH /api/onchain-holder/{id}/toggle 启用/禁用
+ * GET  /api/onchain-holder/status    链状态（区块高度）
+ * </pre>
+ */
+@Controller
+@RequiredArgsConstructor
+public class OnchainHolderController {
+
+    private final OnchainWatchRepository  watchRepo;
+    private final OnchainRpcClient        rpcClient;
+    private final OnchainHolderService    holderService;
+
+    // ── 页面 ──────────────────────────────────────────────────────────
+
+    @GetMapping("/onchain-holder")
+    public String page(Model model) {
+        model.addAttribute("activePage", "onchain-holder");
+        return "onchain-holder";
+    }
+
+    // ── REST ──────────────────────────────────────────────────────────
+
+    @GetMapping("/api/onchain-holder/list")
+    @ResponseBody
+    public List<Map<String, Object>> list() {
+        return watchRepo.findAll().stream().map(this::toMap).toList();
+    }
+
+    @PostMapping("/api/onchain-holder/add")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> add(@RequestBody Map<String, Object> req) {
+        try {
+            OnchainWatch w = new OnchainWatch();
+            w.setTokenName(str(req, "tokenName"));
+            w.setContractAddr(str(req, "contractAddr").toLowerCase());
+            w.setNetwork(str(req, "network").toUpperCase());
+            w.setThresholdMode(str(req, "thresholdMode", "USD").toUpperCase());
+
+            Object tusd = req.get("thresholdUsd");
+            w.setThresholdUsd(tusd != null ? new BigDecimal(String.valueOf(tusd)) : new BigDecimal("50000"));
+
+            Object tamt = req.get("thresholdAmount");
+            if (tamt != null && !String.valueOf(tamt).isBlank()) {
+                w.setThresholdAmount(new BigDecimal(String.valueOf(tamt)));
+            }
+
+            @SuppressWarnings("unchecked")
+            List<String> addrs = (List<String>) req.get("watchedAddrs");
+            if (addrs == null || addrs.isEmpty()) {
+                return ResponseEntity.badRequest().body(Map.of("error", "至少填写一个关注地址"));
+            }
+            w.setWatchedAddrs(addrs.stream().map(String::toLowerCase).toList());
+
+            // 尝试从链上查询精度
+            try {
+                Integer dec = rpcClient.getErc20Decimals(w.getNetwork(), w.getContractAddr());
+                w.setTokenDecimals(dec != null ? dec : 18);
+            } catch (Exception e) {
+                w.setTokenDecimals(18);
+            }
+
+            watchRepo.save(w);
+            return ResponseEntity.ok(Map.of("id", w.getId(), "msg", "保存成功"));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @DeleteMapping("/api/onchain-holder/{id}")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> delete(@PathVariable Long id) {
+        if (!watchRepo.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        watchRepo.deleteById(id);
+        return ResponseEntity.ok(Map.of("msg", "已删除"));
+    }
+
+    @PatchMapping("/api/onchain-holder/{id}/toggle")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> toggle(@PathVariable Long id) {
+        return watchRepo.findById(id).map(w -> {
+            w.setActive(!w.isActive());
+            watchRepo.save(w);
+            return ResponseEntity.ok(Map.of("id", id, "isActive", w.isActive()));
+        }).orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/api/onchain-holder/status")
+    @ResponseBody
+    public Map<String, Object> status() {
+        Map<String, Object> result = new LinkedHashMap<>();
+        Long ethBlock = rpcClient.getBlockNumber("ETH");
+        Long bscBlock = rpcClient.getBlockNumber("BSC");
+        result.put("eth", Map.of("blockNumber", ethBlock != null ? ethBlock : 0, "ok", ethBlock != null));
+        result.put("bsc", Map.of("blockNumber", bscBlock != null ? bscBlock : 0, "ok", bscBlock != null));
+        result.put("serverTime", java.time.LocalDateTime.now().toString());
+        return result;
+    }
+
+    // ── 工具方法 ──────────────────────────────────────────────────────
+
+    private Map<String, Object> toMap(OnchainWatch w) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("id",              w.getId());
+        m.put("tokenName",       w.getTokenName());
+        m.put("contractAddr",    w.getContractAddr());
+        m.put("network",         w.getNetwork());
+        m.put("tokenDecimals",   w.getTokenDecimals());
+        m.put("thresholdMode",   w.getThresholdMode());
+        m.put("thresholdAmount", w.getThresholdAmount());
+        m.put("thresholdUsd",    w.getThresholdUsd());
+        m.put("watchedAddrs",    w.getWatchedAddrs());
+        m.put("isActive",        w.isActive());
+        m.put("createdAt",       w.getCreatedAt() != null ? w.getCreatedAt().toString() : null);
+        return m;
+    }
+
+    private static String str(Map<String, Object> m, String key) {
+        Object v = m.get(key);
+        if (v == null || String.valueOf(v).isBlank()) throw new IllegalArgumentException(key + " 不能为空");
+        return String.valueOf(v).trim();
+    }
+
+    private static String str(Map<String, Object> m, String key, String defaultVal) {
+        Object v = m.get(key);
+        return (v == null || String.valueOf(v).isBlank()) ? defaultVal : String.valueOf(v).trim();
+    }
+}

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/OnchainHolderJob.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/OnchainHolderJob.java
@@ -1,0 +1,46 @@
+package com.deanrobin.aios.dashboard.job;
+
+import com.deanrobin.aios.dashboard.repository.OnchainHolderSnapshotRepository;
+import com.deanrobin.aios.dashboard.service.OnchainHolderService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+/**
+ * 链上持仓监控任务。
+ *
+ * <ul>
+ *   <li>每 60 秒轮询一次所有活跃监控任务</li>
+ *   <li>每天 01:00 清理 30 天前的快照</li>
+ * </ul>
+ */
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class OnchainHolderJob {
+
+    private final OnchainHolderService          holderService;
+    private final OnchainHolderSnapshotRepository snapshotRepo;
+
+    @Scheduled(initialDelay = 30_000, fixedDelay = 60_000)
+    public void checkHolders() {
+        try {
+            holderService.checkAll();
+        } catch (Exception e) {
+            log.error("❌ 链上持仓检查异常", e);
+        }
+    }
+
+    /** 每天 01:00 清理 30 天前的快照，防止表膨胀 */
+    @Scheduled(cron = "0 0 1 * * *")
+    public void cleanupSnapshots() {
+        LocalDateTime cutoff = LocalDateTime.now().minusDays(30);
+        int deleted = snapshotRepo.deleteBySnappedAtBefore(cutoff);
+        if (deleted > 0) {
+            log.info("🗑️ 链上持仓快照清理 deleted={}", deleted);
+        }
+    }
+}

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/model/OnchainHolderSnapshot.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/model/OnchainHolderSnapshot.java
@@ -1,0 +1,48 @@
+package com.deanrobin.aios.dashboard.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "onchain_holder_snapshot",
+       indexes = {
+           @Index(name = "idx_watch_wallet", columnList = "watch_id,wallet_addr"),
+           @Index(name = "idx_snapped_at",   columnList = "snapped_at")
+       })
+public class OnchainHolderSnapshot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "watch_id", nullable = false)
+    private Long watchId;
+
+    @Column(name = "wallet_addr", nullable = false, length = 42)
+    private String walletAddr;
+
+    /** 原始余额（未除精度的整数值）*/
+    @Column(name = "balance_raw", nullable = false, precision = 40, scale = 0)
+    private BigDecimal balanceRaw;
+
+    /** 余额（已除精度）*/
+    @Column(name = "balance_token", nullable = false, precision = 30, scale = 6)
+    private BigDecimal balanceToken;
+
+    /** 快照时代币 USD 价格 */
+    @Column(name = "price_usd", precision = 20, scale = 8)
+    private BigDecimal priceUsd;
+
+    /** 折算 USD 市值 */
+    @Column(name = "value_usd", precision = 20, scale = 2)
+    private BigDecimal valueUsd;
+
+    @Column(name = "block_number", nullable = false)
+    private Long blockNumber;
+
+    @Column(name = "snapped_at", nullable = false)
+    private LocalDateTime snappedAt = LocalDateTime.now();
+}

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/model/OnchainWatch.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/model/OnchainWatch.java
@@ -1,0 +1,68 @@
+package com.deanrobin.aios.dashboard.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Entity
+@Table(name = "onchain_watch",
+       indexes = {
+           @Index(name = "idx_network", columnList = "network"),
+           @Index(name = "idx_active",  columnList = "is_active")
+       })
+public class OnchainWatch {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 代币名称，如 STO */
+    @Column(name = "token_name", nullable = false, length = 50)
+    private String tokenName;
+
+    /** 合约地址 0x... */
+    @Column(name = "contract_addr", nullable = false, length = 42)
+    private String contractAddr;
+
+    /** ETH | BSC */
+    @Column(name = "network", nullable = false, length = 10)
+    private String network;
+
+    /** ERC20 小数位，首次查链获取，默认 18 */
+    @Column(name = "token_decimals", nullable = false)
+    private int tokenDecimals = 18;
+
+    /** TOKEN = 按代币数量比对；USD = 按折算美元比对 */
+    @Column(name = "threshold_mode", nullable = false, length = 10)
+    private String thresholdMode = "USD";
+
+    /** TOKEN 模式下的数量阈值 */
+    @Column(name = "threshold_amount", precision = 30, scale = 4)
+    private BigDecimal thresholdAmount;
+
+    /** USD 模式下的金额阈值（默认 50000）*/
+    @Column(name = "threshold_usd", nullable = false, precision = 20, scale = 2)
+    private BigDecimal thresholdUsd = new BigDecimal("50000");
+
+    /** 关注地址列表，JSON 存储 */
+    @Column(name = "watched_addrs", nullable = false, columnDefinition = "JSON")
+    @Convert(converter = StringListJsonConverter.class)
+    private List<String> watchedAddrs;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive = true;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/model/StringListJsonConverter.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/model/StringListJsonConverter.java
@@ -1,0 +1,36 @@
+package com.deanrobin.aios.dashboard.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Converter
+public class StringListJsonConverter implements AttributeConverter<List<String>, String> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<String> list) {
+        if (list == null) return "[]";
+        try {
+            return MAPPER.writeValueAsString(list);
+        } catch (JsonProcessingException e) {
+            return "[]";
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String json) {
+        if (json == null || json.isBlank()) return new ArrayList<>();
+        try {
+            return MAPPER.readValue(json, new TypeReference<List<String>>() {});
+        } catch (Exception e) {
+            return new ArrayList<>();
+        }
+    }
+}

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/OnchainHolderSnapshotRepository.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/OnchainHolderSnapshotRepository.java
@@ -1,0 +1,20 @@
+package com.deanrobin.aios.dashboard.repository;
+
+import com.deanrobin.aios.dashboard.model.OnchainHolderSnapshot;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface OnchainHolderSnapshotRepository extends JpaRepository<OnchainHolderSnapshot, Long> {
+
+    Optional<OnchainHolderSnapshot> findTopByWatchIdAndWalletAddrOrderBySnappedAtDesc(Long watchId, String walletAddr);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM OnchainHolderSnapshot s WHERE s.snappedAt < :cutoff")
+    int deleteBySnappedAtBefore(LocalDateTime cutoff);
+}

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/OnchainWatchRepository.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/OnchainWatchRepository.java
@@ -1,0 +1,11 @@
+package com.deanrobin.aios.dashboard.repository;
+
+import com.deanrobin.aios.dashboard.model.OnchainWatch;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OnchainWatchRepository extends JpaRepository<OnchainWatch, Long> {
+
+    List<OnchainWatch> findAllByIsActiveTrue();
+}

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/OnchainHolderService.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/OnchainHolderService.java
@@ -1,0 +1,240 @@
+package com.deanrobin.aios.dashboard.service;
+
+import com.deanrobin.aios.dashboard.model.OnchainHolderSnapshot;
+import com.deanrobin.aios.dashboard.model.OnchainWatch;
+import com.deanrobin.aios.dashboard.repository.OnchainHolderSnapshotRepository;
+import com.deanrobin.aios.dashboard.repository.OnchainWatchRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 链上持仓业务逻辑：
+ * <ul>
+ *   <li>轮询每个监控任务的余额</li>
+ *   <li>与上次快照比对，超阈值发飞书告警</li>
+ *   <li>同方向告警 5 分钟内不重复</li>
+ * </ul>
+ */
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class OnchainHolderService {
+
+    @Value("${perp.alert-url}")
+    private String feishuWebhook;
+
+    private final OnchainWatchRepository         watchRepo;
+    private final OnchainHolderSnapshotRepository snapshotRepo;
+    private final OnchainRpcClient               rpcClient;
+    private final WebClient.Builder              webClientBuilder;
+
+    // key = watchId:walletAddr:direction(UP/DOWN), value = 上次告警时间
+    private final ConcurrentHashMap<String, LocalDateTime> lastAlertTime = new ConcurrentHashMap<>();
+
+    private static final DateTimeFormatter FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    // ── 主入口（由 Job 调用）──────────────────────────────────────────
+
+    public void checkAll() {
+        List<OnchainWatch> watches = watchRepo.findAllByIsActiveTrue();
+        if (watches.isEmpty()) return;
+
+        for (OnchainWatch watch : watches) {
+            try {
+                checkWatch(watch);
+            } catch (Exception e) {
+                log.warn("⚠️ 监控任务 {} ({}) 处理异常: {}", watch.getId(), watch.getTokenName(), e.getMessage());
+            }
+        }
+    }
+
+    // ── 单任务处理 ────────────────────────────────────────────────────
+
+    private void checkWatch(OnchainWatch watch) {
+        // 获取代币价格（Binance 现货）
+        BigDecimal tokenPrice = fetchBinancePrice(watch.getTokenName());
+
+        // 获取当前区块号
+        Long blockNumber = rpcClient.getBlockNumber(watch.getNetwork());
+        if (blockNumber == null) {
+            log.warn("⚠️ 无法获取 {} 区块高度，跳过任务 {}", watch.getNetwork(), watch.getId());
+            return;
+        }
+
+        for (String walletAddr : watch.getWatchedAddrs()) {
+            try {
+                processWallet(watch, walletAddr, blockNumber, tokenPrice);
+            } catch (Exception e) {
+                log.warn("⚠️ 处理钱包 {} 失败: {}", walletAddr, e.getMessage());
+            }
+        }
+    }
+
+    private void processWallet(OnchainWatch watch, String walletAddr,
+                                long blockNumber, BigDecimal tokenPrice) {
+        // 1. 获取当前链上余额
+        BigDecimal balanceRaw = rpcClient.getErc20BalanceRaw(
+                watch.getNetwork(), watch.getContractAddr(), walletAddr);
+        if (balanceRaw == null) return;
+
+        int decimals = watch.getTokenDecimals();
+        BigDecimal divisor = BigDecimal.TEN.pow(decimals);
+        BigDecimal balanceToken = balanceRaw.divide(divisor, 6, RoundingMode.DOWN);
+
+        BigDecimal valueUsd = null;
+        if (tokenPrice != null) {
+            valueUsd = balanceToken.multiply(tokenPrice).setScale(2, RoundingMode.HALF_UP);
+        }
+
+        // 2. 查上次快照
+        Optional<OnchainHolderSnapshot> prevOpt =
+                snapshotRepo.findTopByWatchIdAndWalletAddrOrderBySnappedAtDesc(watch.getId(), walletAddr);
+
+        if (prevOpt.isEmpty()) {
+            // 首次快照，仅记录，不告警
+            saveSnapshot(watch, walletAddr, balanceRaw, balanceToken, tokenPrice, valueUsd, blockNumber);
+            log.info("📸 链上持仓首次快照 {}/{} balance={} {}", watch.getTokenName(), walletAddr, balanceToken, watch.getNetwork());
+            return;
+        }
+
+        OnchainHolderSnapshot prev = prevOpt.get();
+        BigDecimal deltaToken = balanceToken.subtract(prev.getBalanceToken());
+
+        // 3. 判断是否超过阈值
+        boolean triggered = false;
+        if ("TOKEN".equals(watch.getThresholdMode()) && watch.getThresholdAmount() != null) {
+            triggered = deltaToken.abs().compareTo(watch.getThresholdAmount()) >= 0;
+        } else {
+            // USD 模式
+            if (tokenPrice != null && tokenPrice.compareTo(BigDecimal.ZERO) > 0) {
+                BigDecimal deltaUsd = deltaToken.abs().multiply(tokenPrice).setScale(2, RoundingMode.HALF_UP);
+                triggered = deltaUsd.compareTo(watch.getThresholdUsd()) >= 0;
+            }
+        }
+
+        if (triggered) {
+            String direction = deltaToken.compareTo(BigDecimal.ZERO) >= 0 ? "UP" : "DOWN";
+            String throttleKey = watch.getId() + ":" + walletAddr + ":" + direction;
+            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime lastAlert = lastAlertTime.get(throttleKey);
+
+            if (lastAlert == null || Duration.between(lastAlert, now).toMinutes() >= 5) {
+                sendFeishuAlert(watch, walletAddr, deltaToken, balanceToken, tokenPrice, valueUsd);
+                lastAlertTime.put(throttleKey, now);
+            }
+        }
+
+        // 4. 保存新快照
+        saveSnapshot(watch, walletAddr, balanceRaw, balanceToken, tokenPrice, valueUsd, blockNumber);
+    }
+
+    private void saveSnapshot(OnchainWatch watch, String walletAddr,
+                               BigDecimal balanceRaw, BigDecimal balanceToken,
+                               BigDecimal priceUsd, BigDecimal valueUsd, long blockNumber) {
+        OnchainHolderSnapshot snap = new OnchainHolderSnapshot();
+        snap.setWatchId(watch.getId());
+        snap.setWalletAddr(walletAddr.toLowerCase());
+        snap.setBalanceRaw(balanceRaw);
+        snap.setBalanceToken(balanceToken);
+        snap.setPriceUsd(priceUsd);
+        snap.setValueUsd(valueUsd);
+        snap.setBlockNumber(blockNumber);
+        snap.setSnappedAt(LocalDateTime.now());
+        snapshotRepo.save(snap);
+    }
+
+    // ── 飞书告警 ─────────────────────────────────────────────────────
+
+    private void sendFeishuAlert(OnchainWatch watch, String walletAddr,
+                                  BigDecimal deltaToken, BigDecimal balanceToken,
+                                  BigDecimal tokenPrice, BigDecimal valueUsd) {
+        String direction = deltaToken.compareTo(BigDecimal.ZERO) >= 0 ? "↑ 增持" : "↓ 减仓";
+        String deltaStr  = (deltaToken.compareTo(BigDecimal.ZERO) >= 0 ? "+" : "") +
+                           fmt(deltaToken.abs()) + " " + watch.getTokenName();
+        String deltaUsdStr = tokenPrice != null
+                ? "（≈ $" + fmt(deltaToken.abs().multiply(tokenPrice)) + " USD）"
+                : "";
+        String balanceStr = fmt(balanceToken) + " " + watch.getTokenName();
+        String valueUsdStr = valueUsd != null ? "（≈ $" + fmt(valueUsd) + " USD）" : "";
+        String priceStr   = tokenPrice != null ? "$" + tokenPrice.toPlainString() + " USD" : "未知";
+        String shortAddr  = shortAddr(walletAddr);
+
+        String text = "🚨 链上持仓变动告警\n\n" +
+                "代币: " + watch.getTokenName() + " (" + watch.getNetwork() + ")\n" +
+                "钱包: " + shortAddr + "\n" +
+                "变化: " + deltaStr + deltaUsdStr + " " + direction + "\n" +
+                "当前余额: " + balanceStr + valueUsdStr + "\n" +
+                "当前价格: " + priceStr + "\n" +
+                "时间: " + LocalDateTime.now().format(FMT) + "\n" +
+                "合约: " + watch.getContractAddr();
+
+        Map<String, Object> body = Map.of(
+            "msg_type", "text",
+            "content",  Map.of("text", text)
+        );
+
+        try {
+            webClientBuilder.build()
+                .post()
+                .uri(feishuWebhook)
+                .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block(Duration.ofSeconds(5));
+            log.info("📣 飞书告警已发送 {}/{}", watch.getTokenName(), shortAddr);
+        } catch (Exception e) {
+            log.warn("⚠️ 飞书告警发送失败: {}", e.getMessage());
+        }
+    }
+
+    // ── Binance 价格 ─────────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    public BigDecimal fetchBinancePrice(String tokenName) {
+        try {
+            String symbol = tokenName.toUpperCase() + "USDT";
+            Map<?, ?> resp = webClientBuilder.baseUrl("https://api.binance.com").build()
+                .get()
+                .uri("/api/v3/ticker/price?symbol=" + symbol)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block(Duration.ofSeconds(5));
+            if (resp == null) return null;
+            Object price = resp.get("price");
+            return price == null ? null : new BigDecimal(String.valueOf(price));
+        } catch (Exception e) {
+            log.debug("Binance 价格查询失败 {}: {}", tokenName, e.getMessage());
+            return null;
+        }
+    }
+
+    // ── 工具方法 ──────────────────────────────────────────────────────
+
+    /** 格式化数字，加千位分隔符 */
+    private static String fmt(BigDecimal v) {
+        if (v == null) return "0";
+        return String.format("%,.2f", v);
+    }
+
+    /** 地址缩写：0xABCD...WXYZ */
+    private static String shortAddr(String addr) {
+        if (addr == null || addr.length() < 10) return addr;
+        return addr.substring(0, 6) + "..." + addr.substring(addr.length() - 4);
+    }
+}

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/OnchainRpcClient.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/OnchainRpcClient.java
@@ -1,0 +1,134 @@
+package com.deanrobin.aios.dashboard.service;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * ETH / BSC JSON-RPC 客户端。
+ *
+ * <p>使用公开 RPC 节点，无需 API Key：
+ * <ul>
+ *   <li>ETH: https://eth.llamarpc.com</li>
+ *   <li>BSC: https://bsc-dataseed.binance.org/</li>
+ * </ul>
+ *
+ * <p>支持：
+ * <ul>
+ *   <li>{@link #getBlockNumber(String)} — eth_blockNumber</li>
+ *   <li>{@link #getErc20Balance(String, String, String)} — balanceOf(address)</li>
+ *   <li>{@link #getErc20Decimals(String, String)} — decimals()</li>
+ * </ul>
+ */
+@Log4j2
+@Service
+public class OnchainRpcClient {
+
+    @Value("${onchain.eth-rpc:https://eth.llamarpc.com}")
+    private String ethRpc;
+
+    @Value("${onchain.bsc-rpc:https://bsc-dataseed.binance.org/}")
+    private String bscRpc;
+
+    private final WebClient.Builder webClientBuilder;
+
+    public OnchainRpcClient(WebClient.Builder webClientBuilder) {
+        this.webClientBuilder = webClientBuilder;
+    }
+
+    // ── 获取最新区块号 ──────────────────────────────────────────────
+
+    public Long getBlockNumber(String network) {
+        try {
+            Map<?, ?> resp = rpcCall(rpcUrl(network), "eth_blockNumber", List.of());
+            if (resp == null) return null;
+            String hex = (String) resp.get("result");
+            return hex == null ? null : Long.parseLong(hex.substring(2), 16);
+        } catch (Exception e) {
+            log.warn("⚠️ getBlockNumber {} 失败: {}", network, e.getMessage());
+            return null;
+        }
+    }
+
+    // ── 查询 ERC20 余额（原始整数，未除精度）────────────────────────
+
+    public BigDecimal getErc20BalanceRaw(String network, String contractAddr, String walletAddr) {
+        try {
+            // balanceOf(address) selector = 0x70a08231
+            // 参数：32 字节补零的地址
+            String paddedAddr = padAddress(walletAddr);
+            String data = "0x70a08231" + paddedAddr;
+            String callResult = ethCall(network, contractAddr, data);
+            if (callResult == null || callResult.equals("0x")) return BigDecimal.ZERO;
+            return new BigDecimal(new BigInteger(callResult.substring(2), 16));
+        } catch (Exception e) {
+            log.warn("⚠️ getErc20BalanceRaw {}/{}/{} 失败: {}", network, contractAddr, walletAddr, e.getMessage());
+            return null;
+        }
+    }
+
+    // ── 查询 ERC20 精度 ──────────────────────────────────────────────
+
+    public Integer getErc20Decimals(String network, String contractAddr) {
+        try {
+            // decimals() selector = 0x313ce567
+            String callResult = ethCall(network, contractAddr, "0x313ce567");
+            if (callResult == null || callResult.equals("0x")) return 18;
+            return new BigInteger(callResult.substring(2), 16).intValue();
+        } catch (Exception e) {
+            log.warn("⚠️ getErc20Decimals {}/{} 失败，默认 18: {}", network, contractAddr, e.getMessage());
+            return 18;
+        }
+    }
+
+    // ── 内部工具方法 ─────────────────────────────────────────────────
+
+    private String ethCall(String network, String toAddr, String data) {
+        Map<String, String> callParams = Map.of("to", toAddr, "data", data);
+        Map<?, ?> resp = rpcCall(rpcUrl(network), "eth_call", List.of(callParams, "latest"));
+        if (resp == null) return null;
+        return (String) resp.get("result");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<?, ?> rpcCall(String url, String method, Object params) {
+        Map<String, Object> body = Map.of(
+            "jsonrpc", "2.0",
+            "method",  method,
+            "params",  params,
+            "id",      1
+        );
+        try {
+            return webClientBuilder.baseUrl(url).build()
+                .post()
+                .uri("/")
+                .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block(Duration.ofSeconds(10));
+        } catch (Exception e) {
+            log.warn("⚠️ RPC 调用失败 {}/{}: {}", url, method, e.getMessage());
+            return null;
+        }
+    }
+
+    private String rpcUrl(String network) {
+        return "BSC".equalsIgnoreCase(network) ? bscRpc : ethRpc;
+    }
+
+    /**
+     * 将 0x 前缀地址（40 字符）扩展为 64 字符的 ABI 编码参数（左补零）。
+     */
+    private static String padAddress(String addr) {
+        String clean = addr.startsWith("0x") ? addr.substring(2) : addr;
+        return "0".repeat(64 - clean.length()) + clean.toLowerCase();
+    }
+}

--- a/dashboard/src/main/resources/application.yml
+++ b/dashboard/src/main/resources/application.yml
@@ -63,3 +63,8 @@ perp:
     overview-ttl-seconds: 300      # overview 缓存 5 分钟
     tx-history-ttl-seconds: 30     # tx_history 缓存 30 秒
     tx-history-limit: 50           # 每次拉取最近多少笔交易
+
+# ── 链上持仓监控 RPC 配置 ─────────────────────────────────────────
+onchain:
+  eth-rpc: https://eth.llamarpc.com
+  bsc-rpc: https://bsc-dataseed.binance.org/

--- a/dashboard/src/main/resources/templates/layout.html
+++ b/dashboard/src/main/resources/templates/layout.html
@@ -405,10 +405,13 @@
         <a class="nav-link" th:classappend="${activePage=='signals'    ? ' active' : ''}" href="/signals">⚡ 买入信号</a>
         <a class="nav-link" th:classappend="${activePage=='pump'       ? ' active' : ''}" href="/pump">🚀 新币发射</a>
         <a class="nav-link" th:classappend="${activePage=='smart-money'? ' active' : ''}" href="/smart-money">🧠 聪明钱</a>
+        <a class="nav-link" th:classappend="${activePage=='onchain-holder'? ' active' : ''}" href="/onchain-holder">🔍 链上持仓</a>
         <a class="nav-link" th:classappend="${activePage=='portfolio'  ? ' active' : ''}" href="/portfolio">💼 我的持仓</a>
         <a class="nav-link" th:classappend="${activePage=='my-addresses'? ' active' : ''}" href="/my-addresses">📌 关注地址</a>
+        <!--
         <a class="nav-link" th:classappend="${activePage=='trade'       ? ' active' : ''}" href="/trade">⚡ 交易</a>
         <a class="nav-link" th:classappend="${activePage=='transfer'    ? ' active' : ''}" href="/transfer">💸 转账</a>
+        -->
         <a class="nav-link" th:classappend="${activePage=='perps'       ? ' active' : ''}" href="/perps">📈 Perps</a>
         <a class="nav-link" th:classappend="${activePage=='qmt'         ? ' active' : ''}" href="/qmt">🤖 QMT</a>
     </div>

--- a/dashboard/src/main/resources/templates/onchain-holder.html
+++ b/dashboard/src/main/resources/templates/onchain-holder.html
@@ -1,0 +1,423 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout :: page('链上持仓', ~{::main})}">
+<body>
+<main>
+<style>
+/* ── 链状态卡片 ── */
+.chain-status-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+    margin-bottom: 20px;
+}
+.chain-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 16px 20px;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+}
+.chain-icon {
+    font-size: 28px;
+    line-height: 1;
+}
+.chain-info { flex: 1; min-width: 0; }
+.chain-name { font-weight: 600; font-size: 15px; color: var(--t1); }
+.chain-block { font-size: 13px; color: var(--t2); font-family: 'JetBrains Mono', monospace; margin-top: 2px; }
+.chain-dot {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--t3); flex-shrink: 0;
+}
+.chain-dot.online { background: var(--green); box-shadow: 0 0 0 3px rgba(16,185,129,.2); }
+
+/* ── 添加表单 ── */
+.add-form-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 22px 24px;
+    margin-bottom: 20px;
+}
+.add-form-card h5 { font-weight: 600; font-size: 15px; margin-bottom: 16px; color: var(--t1); }
+.form-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+.form-row-full { margin-bottom: 12px; }
+.form-label-sm { font-size: 12px; color: var(--t2); margin-bottom: 4px; font-weight: 500; }
+.form-control-sm, .form-select-sm {
+    font-size: 13px;
+    border: 1px solid var(--border-m);
+    border-radius: 8px;
+    padding: 7px 10px;
+    background: var(--bg-page);
+    color: var(--t1);
+    width: 100%;
+    outline: none;
+    transition: border .15s;
+}
+.form-control-sm:focus, .form-select-sm:focus {
+    border-color: var(--blue);
+    background: #fff;
+}
+.threshold-row {
+    display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+}
+.threshold-row .tmode-btn {
+    padding: 5px 14px; font-size: 12px; border-radius: 6px; cursor: pointer;
+    border: 1px solid var(--border-m); background: var(--bg-page); color: var(--t2);
+    font-weight: 500; transition: all .15s;
+}
+.threshold-row .tmode-btn.active {
+    background: var(--blue); color: #fff; border-color: var(--blue);
+}
+#addr-list { display: flex; flex-direction: column; gap: 8px; }
+.addr-row { display: flex; gap: 8px; align-items: center; }
+.addr-row .remove-addr {
+    color: var(--t3); cursor: pointer; font-size: 16px; line-height: 1;
+    padding: 0 4px; flex-shrink: 0;
+}
+.addr-row .remove-addr:hover { color: var(--red, #ef4444); }
+.btn-add-addr {
+    font-size: 12px; color: var(--blue); cursor: pointer;
+    background: none; border: none; padding: 0; margin-top: 4px;
+    display: inline-flex; align-items: center; gap: 4px;
+}
+.btn-save {
+    background: var(--blue); color: #fff; border: none;
+    padding: 9px 24px; border-radius: 8px; font-size: 14px; font-weight: 500;
+    cursor: pointer; transition: opacity .15s; margin-top: 12px;
+}
+.btn-save:hover { opacity: .85; }
+.btn-save:disabled { opacity: .5; cursor: not-allowed; }
+
+/* ── 监控任务列表 ── */
+.watch-list-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    overflow: hidden;
+}
+.watch-list-card .list-header {
+    padding: 14px 20px;
+    border-bottom: 1px solid var(--border);
+    font-weight: 600; font-size: 15px; color: var(--t1);
+    display: flex; align-items: center; justify-content: space-between;
+}
+.watch-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.watch-table th {
+    background: var(--bg-page); color: var(--t3); font-weight: 500;
+    font-size: 11px; text-transform: uppercase; letter-spacing: .05em;
+    padding: 10px 16px; text-align: left; border-bottom: 1px solid var(--border);
+}
+.watch-table td {
+    padding: 12px 16px; border-bottom: 1px solid var(--border);
+    color: var(--t1); vertical-align: middle;
+}
+.watch-table tr:last-child td { border-bottom: none; }
+.watch-table tr:hover td { background: var(--bg-hover); }
+.tag-network {
+    display: inline-block; padding: 2px 8px; border-radius: 4px;
+    font-size: 11px; font-weight: 600; letter-spacing: .03em;
+}
+.tag-eth { background: #eff6ff; color: #2563eb; }
+.tag-bsc { background: #fefce8; color: #ca8a04; }
+.status-dot {
+    display: inline-block; width: 7px; height: 7px; border-radius: 50%; margin-right: 5px;
+}
+.status-dot.on { background: var(--green); }
+.status-dot.off { background: var(--t3); }
+.addr-list-cell { font-family: 'JetBrains Mono', monospace; font-size: 11px; color: var(--t2); }
+.btn-icon {
+    background: none; border: none; cursor: pointer; color: var(--t3);
+    font-size: 15px; padding: 2px 5px; border-radius: 4px; transition: all .15s;
+}
+.btn-icon:hover { color: var(--t1); background: var(--bg-hover); }
+.btn-icon.del:hover { color: #ef4444; }
+.empty-hint { text-align: center; padding: 32px; color: var(--t3); font-size: 13px; }
+
+/* ── 响应式 ── */
+@media (max-width: 768px) {
+    .chain-status-grid { grid-template-columns: 1fr; }
+    .form-row { grid-template-columns: 1fr; }
+}
+</style>
+
+<div class="container" style="max-width:900px; padding: 24px 16px;">
+
+    <!-- 页面标题 -->
+    <div style="margin-bottom:20px;">
+        <h1 style="font-size:22px;font-weight:700;color:var(--t1);margin:0;">🔍 链上持仓监控</h1>
+        <p style="font-size:13px;color:var(--t2);margin:4px 0 0;">监控 ERC20 代币大额持仓变动，超阈值自动飞书告警</p>
+    </div>
+
+    <!-- 链状态 -->
+    <div class="chain-status-grid">
+        <div class="chain-card">
+            <div class="chain-icon">⛓</div>
+            <div class="chain-info">
+                <div class="chain-name">Ethereum (ETH)</div>
+                <div class="chain-block" id="eth-block">区块: 加载中...</div>
+            </div>
+            <div class="chain-dot" id="eth-dot"></div>
+        </div>
+        <div class="chain-card">
+            <div class="chain-icon">⛓</div>
+            <div class="chain-info">
+                <div class="chain-name">BNB Chain (BSC)</div>
+                <div class="chain-block" id="bsc-block">区块: 加载中...</div>
+            </div>
+            <div class="chain-dot" id="bsc-dot"></div>
+        </div>
+    </div>
+
+    <!-- 添加监控任务 -->
+    <div class="add-form-card">
+        <h5>＋ 添加监控任务</h5>
+
+        <div class="form-row">
+            <div>
+                <div class="form-label-sm">代币名称</div>
+                <input type="text" id="f-token-name" class="form-control-sm" placeholder="如 STO">
+            </div>
+            <div>
+                <div class="form-label-sm">网络</div>
+                <select id="f-network" class="form-select-sm">
+                    <option value="ETH">Ethereum (ETH)</option>
+                    <option value="BSC">BNB Chain (BSC)</option>
+                </select>
+            </div>
+            <div>
+                <div class="form-label-sm">告警模式</div>
+                <div class="threshold-row" style="margin-top:4px;">
+                    <button class="tmode-btn active" data-mode="USD" onclick="setMode('USD')">USD 金额</button>
+                    <button class="tmode-btn" data-mode="TOKEN" onclick="setMode('TOKEN')">代币数量</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="form-row-full">
+            <div class="form-label-sm">合约地址</div>
+            <input type="text" id="f-contract" class="form-control-sm" placeholder="0x...">
+        </div>
+
+        <div class="form-row">
+            <div id="wrap-usd">
+                <div class="form-label-sm">USD 阈值（默认 50K）</div>
+                <input type="number" id="f-threshold-usd" class="form-control-sm" value="50000" min="1">
+            </div>
+            <div id="wrap-token" style="display:none;">
+                <div class="form-label-sm">代币数量阈值</div>
+                <input type="number" id="f-threshold-amount" class="form-control-sm" placeholder="如 10000" min="0">
+            </div>
+            <div></div>
+        </div>
+
+        <div class="form-label-sm" style="margin-bottom:6px;">关注地址（最多 20 个）</div>
+        <div id="addr-list">
+            <div class="addr-row">
+                <input type="text" class="form-control-sm addr-input" placeholder="0x...">
+            </div>
+        </div>
+        <button class="btn-add-addr" onclick="addAddrRow()">＋ 添加更多地址</button>
+
+        <div>
+            <button class="btn-save" id="btn-save" onclick="saveWatch()">保存监控任务</button>
+            <span id="save-msg" style="font-size:12px;color:var(--t2);margin-left:10px;"></span>
+        </div>
+    </div>
+
+    <!-- 监控任务列表 -->
+    <div class="watch-list-card">
+        <div class="list-header">
+            <span>监控任务列表</span>
+            <span id="watch-count" style="font-size:12px;color:var(--t3);font-weight:400;"></span>
+        </div>
+        <div id="watch-list-body">
+            <div class="empty-hint">暂无监控任务</div>
+        </div>
+    </div>
+
+</div>
+
+<script>
+let thresholdMode = 'USD';
+
+// ── 阈值模式切换 ──────────────────────────────────────
+function setMode(m) {
+    thresholdMode = m;
+    document.querySelectorAll('.tmode-btn').forEach(b => {
+        b.classList.toggle('active', b.dataset.mode === m);
+    });
+    document.getElementById('wrap-usd').style.display   = m === 'USD'   ? '' : 'none';
+    document.getElementById('wrap-token').style.display = m === 'TOKEN' ? '' : 'none';
+}
+
+// ── 地址行管理 ───────────────────────────────────────
+function addAddrRow() {
+    const list = document.getElementById('addr-list');
+    if (list.children.length >= 20) return;
+    const row = document.createElement('div');
+    row.className = 'addr-row';
+    row.innerHTML = `<input type="text" class="form-control-sm addr-input" placeholder="0x...">
+        <span class="remove-addr" onclick="this.parentElement.remove()">×</span>`;
+    list.appendChild(row);
+}
+
+// ── 保存监控任务 ─────────────────────────────────────
+async function saveWatch() {
+    const btn = document.getElementById('btn-save');
+    const msg = document.getElementById('save-msg');
+
+    const tokenName   = document.getElementById('f-token-name').value.trim();
+    const contractAddr = document.getElementById('f-contract').value.trim();
+    const network     = document.getElementById('f-network').value;
+    const thresholdUsd    = parseFloat(document.getElementById('f-threshold-usd').value) || 50000;
+    const thresholdAmount = parseFloat(document.getElementById('f-threshold-amount').value) || null;
+    const watchedAddrs = [...document.querySelectorAll('.addr-input')]
+        .map(i => i.value.trim()).filter(v => v.length > 0);
+
+    if (!tokenName) { msg.textContent = '请填写代币名称'; return; }
+    if (!contractAddr) { msg.textContent = '请填写合约地址'; return; }
+    if (watchedAddrs.length === 0) { msg.textContent = '至少填写一个关注地址'; return; }
+
+    btn.disabled = true;
+    msg.textContent = '保存中...';
+
+    const body = { tokenName, contractAddr, network, thresholdMode,
+                   thresholdUsd, thresholdAmount, watchedAddrs };
+
+    try {
+        const resp = await fetch('/api/onchain-holder/add', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(body)
+        });
+        const data = await resp.json();
+        if (resp.ok) {
+            msg.textContent = '✅ 保存成功';
+            setTimeout(() => { msg.textContent = ''; }, 3000);
+            resetForm();
+            loadWatchList();
+        } else {
+            msg.textContent = '❌ ' + (data.error || '保存失败');
+        }
+    } catch(e) {
+        msg.textContent = '❌ 网络错误';
+    } finally {
+        btn.disabled = false;
+    }
+}
+
+function resetForm() {
+    document.getElementById('f-token-name').value = '';
+    document.getElementById('f-contract').value = '';
+    document.getElementById('f-threshold-usd').value = '50000';
+    document.getElementById('f-threshold-amount').value = '';
+    document.getElementById('addr-list').innerHTML =
+        `<div class="addr-row"><input type="text" class="form-control-sm addr-input" placeholder="0x..."></div>`;
+    setMode('USD');
+}
+
+// ── 加载监控任务列表 ──────────────────────────────────
+async function loadWatchList() {
+    try {
+        const data = await fetch('/api/onchain-holder/list').then(r => r.json());
+        const cnt  = document.getElementById('watch-count');
+        const body = document.getElementById('watch-list-body');
+        cnt.textContent = data.length + ' 个任务';
+
+        if (data.length === 0) {
+            body.innerHTML = '<div class="empty-hint">暂无监控任务，请添加</div>';
+            return;
+        }
+
+        const rows = data.map(w => {
+            const addrs = (w.watchedAddrs || []).map(a =>
+                a.substring(0,6) + '...' + a.substring(a.length-4)).join('<br>');
+            const threshold = w.thresholdMode === 'TOKEN'
+                ? (w.thresholdAmount ? fmtNum(w.thresholdAmount) + ' ' + w.tokenName : '—')
+                : '$' + fmtNum(w.thresholdUsd) + ' USD';
+            const netTag = w.network === 'BSC'
+                ? '<span class="tag-network tag-bsc">BSC</span>'
+                : '<span class="tag-network tag-eth">ETH</span>';
+            const activeBtn = w.isActive
+                ? `<button class="btn-icon" title="禁用" onclick="toggleWatch(${w.id})">⏸</button>`
+                : `<button class="btn-icon" title="启用" onclick="toggleWatch(${w.id})">▶️</button>`;
+            return `<tr>
+                <td><strong>${escHtml(w.tokenName)}</strong></td>
+                <td>${netTag}</td>
+                <td style="font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--t2);">${escHtml(w.contractAddr.substring(0,6)+'...'+w.contractAddr.substring(w.contractAddr.length-4))}</td>
+                <td class="addr-list-cell">${addrs}</td>
+                <td>${threshold}</td>
+                <td><span class="status-dot ${w.isActive?'on':'off'}"></span>${w.isActive?'运行中':'已暂停'}</td>
+                <td>${activeBtn}<button class="btn-icon del" title="删除" onclick="deleteWatch(${w.id})">🗑</button></td>
+            </tr>`;
+        }).join('');
+
+        body.innerHTML = `<table class="watch-table">
+            <thead><tr>
+                <th>代币</th><th>网络</th><th>合约</th>
+                <th>关注地址</th><th>告警阈值</th><th>状态</th><th>操作</th>
+            </tr></thead>
+            <tbody>${rows}</tbody>
+        </table>`;
+    } catch(e) {
+        console.error('加载监控任务失败', e);
+    }
+}
+
+async function deleteWatch(id) {
+    if (!confirm('确认删除这个监控任务？')) return;
+    await fetch(`/api/onchain-holder/${id}`, { method: 'DELETE' });
+    loadWatchList();
+}
+
+async function toggleWatch(id) {
+    await fetch(`/api/onchain-holder/${id}/toggle`, { method: 'PATCH' });
+    loadWatchList();
+}
+
+// ── 链状态 ────────────────────────────────────────────
+async function loadChainStatus() {
+    try {
+        const data = await fetch('/api/onchain-holder/status').then(r => r.json());
+        setChain('eth', data.eth);
+        setChain('bsc', data.bsc);
+    } catch(e) {}
+}
+
+function setChain(chain, info) {
+    const block = document.getElementById(chain + '-block');
+    const dot   = document.getElementById(chain + '-dot');
+    if (info && info.ok) {
+        block.textContent = '区块: #' + info.blockNumber.toLocaleString();
+        dot.className = 'chain-dot online';
+    } else {
+        block.textContent = '区块: 连接失败';
+        dot.className = 'chain-dot';
+    }
+}
+
+// ── 工具函数 ──────────────────────────────────────────
+function fmtNum(v) {
+    return Number(v).toLocaleString('en-US', {maximumFractionDigits: 0});
+}
+function escHtml(s) {
+    return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
+// ── 初始化 ────────────────────────────────────────────
+loadWatchList();
+loadChainStatus();
+setInterval(loadChainStatus, 30_000);
+setInterval(loadWatchList,   60_000);
+</script>
+</main>
+</body>
+</html>

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -120,3 +120,36 @@ CREATE TABLE IF NOT EXISTS kline_bar (
     INDEX idx_symbol_bar (symbol, bar),
     INDEX idx_open_time  (open_time)
 );
+
+-- ── 链上持仓监控任务表 ──────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS onchain_watch (
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY,
+    token_name       VARCHAR(50)   NOT NULL COMMENT '代币名称，如 STO',
+    contract_addr    VARCHAR(42)   NOT NULL COMMENT '合约地址 0x...',
+    network          VARCHAR(10)   NOT NULL COMMENT 'ETH | BSC',
+    token_decimals   TINYINT       NOT NULL DEFAULT 18 COMMENT '代币精度',
+    threshold_mode   VARCHAR(10)   NOT NULL DEFAULT 'USD' COMMENT 'TOKEN | USD',
+    threshold_amount DECIMAL(30,4) COMMENT '代币数量阈值（TOKEN 模式）',
+    threshold_usd    DECIMAL(20,2) NOT NULL DEFAULT 50000 COMMENT 'USD 阈值（默认 50000）',
+    watched_addrs    JSON          NOT NULL COMMENT '["0xABC","0xDEF"]',
+    is_active        TINYINT(1)    NOT NULL DEFAULT 1,
+    created_at       DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at       DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_network (network),
+    INDEX idx_active  (is_active)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ── 链上持仓余额快照表 ──────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS onchain_holder_snapshot (
+    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    watch_id       BIGINT        NOT NULL COMMENT 'FK -> onchain_watch.id',
+    wallet_addr    VARCHAR(42)   NOT NULL COMMENT '钱包地址',
+    balance_raw    DECIMAL(40,0) NOT NULL COMMENT '原始余额（未除精度）',
+    balance_token  DECIMAL(30,6) NOT NULL COMMENT '余额（除精度后）',
+    price_usd      DECIMAL(20,8) COMMENT '快照时代币 USD 价格',
+    value_usd      DECIMAL(20,2) COMMENT '折算 USD 市值',
+    block_number   BIGINT        NOT NULL COMMENT '取余额时的区块高度',
+    snapped_at     DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_watch_wallet (watch_id, wallet_addr),
+    INDEX idx_snapped_at   (snapped_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/docs/onchain_holder.md
+++ b/docs/onchain_holder.md
@@ -1,0 +1,250 @@
+# 链上持仓监控 (OnchainHolder) — 功能设计文档
+
+> 状态：设计稿 v1.0 | 日期：2026-04-06
+
+---
+
+## 一、功能概述
+
+用户在页面添加"监控任务"（`OnchainWatch`），指定一个 ERC20 代币合约 + 一组钱包地址。
+后台 Job 每 60 秒轮询一次链上余额，当余额变化折算 USD 超过阈值，立即通过 **飞书 Webhook** 告警。
+
+> **命名约定**
+> - 页面显示：**监控任务**（Watch Task）
+> - Java 实体：`OnchainWatch`
+> - URL slug：`/onchain-holder`
+
+---
+
+## 二、页面布局
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  🔍 链上持仓监控                                                 │
+│                                                                  │
+│  ┌──── 链状态 ─────────────────────────────────────────┐         │
+│  │  ⛓ ETH   最新区块: 21,234,567   延迟: 2s ago        │         │
+│  │  ⛓ BSC   最新区块: 38,901,234   延迟: 3s ago        │         │
+│  └──────────────────────────────────────────────────────┘        │
+│                                                                  │
+│  ┌──── 添加监控任务 ────────────────────────────────────┐         │
+│  │ 代币名称: [____________]  网络: [ETH ▼]              │         │
+│  │ 合约地址: [0x_______________________________]        │         │
+│  │ 关注地址: [0x_______________________________]        │         │
+│  │          [+ 添加更多地址]                            │         │
+│  │ 告警阈值: 代币数量 [__________] 或                   │         │
+│  │           USD 价值 [50] K  (默认 50K)               │         │
+│  │          [✅ 保存任务]                               │         │
+│  └──────────────────────────────────────────────────────┘        │
+│                                                                  │
+│  ┌──── 监控任务列表 ────────────────────────────────────┐         │
+│  │ 代币   网络  合约             地址数  阈值   状态  操作 │        │
+│  │ STO    BSC   0xabc...         3       50K USD  ✅  🗑   │        │
+│  │ USDT   ETH   0xdai...         1       100K USD ✅  🗑   │        │
+│  └──────────────────────────────────────────────────────┘        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 三、数据库设计
+
+### 3.1 `onchain_watch` — 监控任务表
+
+```sql
+CREATE TABLE IF NOT EXISTS onchain_watch (
+    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    token_name     VARCHAR(50)  NOT NULL COMMENT '代币名称，如 STO',
+    contract_addr  VARCHAR(42)  NOT NULL COMMENT '合约地址 0x...',
+    network        VARCHAR(10)  NOT NULL COMMENT 'ETH | BSC',
+    token_decimals TINYINT      NOT NULL DEFAULT 18 COMMENT '代币精度，首次查链获取',
+    -- 阈值配置（二选一）
+    threshold_mode VARCHAR(10)  NOT NULL DEFAULT 'USD' COMMENT 'TOKEN | USD',
+    threshold_amount DECIMAL(30,4) COMMENT '代币数量阈值（TOKEN 模式）',
+    threshold_usd  DECIMAL(20,2) NOT NULL DEFAULT 50000 COMMENT 'USD 阈值（USD 模式，默认 50000）',
+    -- 关注地址（JSON 数组，最多 20 个）
+    watched_addrs  JSON         NOT NULL COMMENT '["0xABC","0xDEF"]',
+    -- 状态
+    is_active      TINYINT(1)   NOT NULL DEFAULT 1,
+    created_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_network (network),
+    INDEX idx_active  (is_active)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+### 3.2 `onchain_holder_snapshot` — 余额快照表
+
+```sql
+CREATE TABLE IF NOT EXISTS onchain_holder_snapshot (
+    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    watch_id       BIGINT       NOT NULL COMMENT 'FK -> onchain_watch.id',
+    wallet_addr    VARCHAR(42)  NOT NULL COMMENT '钱包地址',
+    balance_raw    DECIMAL(40,0) NOT NULL COMMENT '原始余额（不除以精度）',
+    balance_token  DECIMAL(30,6) NOT NULL COMMENT '余额（除以精度后）',
+    price_usd      DECIMAL(20,8) COMMENT '快照时代币 USD 价格',
+    value_usd      DECIMAL(20,2) COMMENT '折算 USD 市值',
+    block_number   BIGINT       NOT NULL COMMENT '取余额时的区块高度',
+    snapped_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_watch_wallet (watch_id, wallet_addr),
+    INDEX idx_snapped_at   (snapped_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+---
+
+## 四、后端实现
+
+### 4.1 RPC 调用方式
+
+使用各链的**公开 JSON-RPC**，无需 API Key（限速较低，对监控场景足够）：
+
+| 链   | RPC Endpoint（可配置）                              |
+|------|-----------------------------------------------------|
+| ETH  | `https://eth.llamarpc.com`                          |
+| BSC  | `https://bsc-dataseed.binance.org/`                 |
+
+**获取最新区块高度**
+```json
+POST /
+{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}
+→ {"result":"0x144a5f7"} // hex → Long
+```
+
+**查询 ERC20 balanceOf(address)**
+```json
+POST /
+{
+  "jsonrpc":"2.0","method":"eth_call",
+  "params":[{
+    "to":"0x{contractAddr}",
+    "data":"0x70a08231000000000000000000000000{walletAddr_no0x_padded32}"
+  },"latest"],
+  "id":1
+}
+→ {"result":"0x000...0064"} // hex → BigInteger
+```
+
+**查询 ERC20 decimals()**
+```json
+"data":"0x313ce567"  // decimals() function selector
+```
+
+**价格来源**：Binance 现货 `GET https://api.binance.com/api/v3/ticker/price?symbol={TOKEN}USDT`
+
+### 4.2 类结构
+
+```
+model/
+  OnchainWatch.java              // @Entity, watched_addrs 用 @Convert(JSON)
+  OnchainHolderSnapshot.java     // @Entity
+
+repository/
+  OnchainWatchRepository.java    // findAllByIsActiveTrue()
+  OnchainHolderSnapshotRepository.java
+    // findTopByWatchIdAndWalletAddrOrderBySnappedAtDesc()
+
+service/
+  OnchainRpcClient.java          // WebClient, eth_blockNumber / eth_call
+  OnchainHolderService.java      // 业务逻辑：余额对比、飞书告警
+
+job/
+  OnchainHolderJob.java          // @Scheduled fixedDelay=60s
+
+controller/
+  OnchainHolderController.java   // REST CRUD + /api/onchain-holder/status
+```
+
+### 4.3 Job 执行流程
+
+```
+OnchainHolderJob.checkAll() (每 60s)
+├── 1. 读取所有 is_active=1 的监控任务
+├── 2. 对每个任务:
+│   ├── a. 获取当前 Binance 价格（USD）
+│   ├── b. 查询最新区块号
+│   └── c. 对每个 watched_addrs:
+│       ├── i.  eth_call balanceOf → balance_token
+│       ├── ii. 查库获取上次快照余额
+│       ├── iii. 计算差值 delta_token / delta_usd
+│       ├── iv. 若 |delta_usd| >= threshold_usd → 飞书告警
+│       └── v.  保存新快照
+└── 3. 睡眠至下次调度
+```
+
+### 4.4 飞书告警格式
+
+```
+🚨 链上持仓变动告警
+
+代币: STO (BSC)
+钱包: 0xABC...DEF
+变化: +12,345.67 STO（≈ $61,728 USD）↑
+当前余额: 234,567.89 STO（≈ $1,172,839 USD）
+当前价格: $5.00 USD
+时间: 2026-04-06 14:30:00
+合约: 0x{contractAddr}
+```
+
+---
+
+## 五、API 设计
+
+| 方法   | 路径                           | 说明                          |
+|--------|-------------------------------|-------------------------------|
+| GET    | `/onchain-holder`             | 页面（Thymeleaf）              |
+| GET    | `/api/onchain-holder/list`    | 返回所有监控任务                |
+| POST   | `/api/onchain-holder/add`     | 新增监控任务                    |
+| DELETE | `/api/onchain-holder/{id}`    | 删除监控任务                    |
+| PATCH  | `/api/onchain-holder/{id}/toggle` | 启用/禁用                  |
+| GET    | `/api/onchain-holder/status`  | 返回 ETH/BSC 最新区块高度       |
+
+### POST `/api/onchain-holder/add` 请求体
+
+```json
+{
+  "tokenName": "STO",
+  "contractAddr": "0xABC...",
+  "network": "BSC",
+  "thresholdMode": "USD",
+  "thresholdUsd": 50000,
+  "watchedAddrs": ["0xAAA...", "0xBBB..."]
+}
+```
+
+---
+
+## 六、配置（application.yml）
+
+```yaml
+onchain:
+  eth-rpc: https://eth.llamarpc.com
+  bsc-rpc: https://bsc-dataseed.binance.org/
+```
+
+---
+
+## 七、边界情况处理
+
+| 情况                         | 处理方式                                              |
+|------------------------------|-------------------------------------------------------|
+| RPC 超时/失败                 | 跳过本轮，不更新快照，log.warn                         |
+| Binance 无该代币价格           | threshold_mode 自动降级为 TOKEN 模式比对               |
+| 合约 decimals 查询失败         | 默认 18                                               |
+| 首次添加任务（无快照）           | 立即拍一次快照作为基准，不告警                          |
+| 同一钱包 60s 内多次告警         | 记录上次告警时间，同方向 5 分钟内不重复告警              |
+
+---
+
+## 八、待办清单
+
+- [ ] DDL：`db/schema.sql` 追加两张表
+- [ ] `model/` 两个实体
+- [ ] `repository/` 两个 Repository
+- [ ] `service/OnchainRpcClient.java`
+- [ ] `service/OnchainHolderService.java`
+- [ ] `job/OnchainHolderJob.java`
+- [ ] `controller/OnchainHolderController.java`
+- [ ] `templates/onchain-holder.html`
+- [ ] `application.yml` 增加 `onchain` 配置块
+- [ ] `layout.html` 已添加导航链接 ✅


### PR DESCRIPTION
- layout.html: 隐藏 交易/转账 导航，新增「链上持仓」导航项
- db/schema.sql: 新增 onchain_watch + onchain_holder_snapshot 两张表
- model: OnchainWatch (监控任务)、OnchainHolderSnapshot (余额快照)、StringListJsonConverter
- repository: OnchainWatchRepository、OnchainHolderSnapshotRepository
- service/OnchainRpcClient: ETH/BSC JSON-RPC (eth_blockNumber / balanceOf / decimals)
- service/OnchainHolderService: 余额对比、阈值触发、飞书告警（同方向5min防刷）
- job/OnchainHolderJob: 每60s轮询余额，每天01:00清理30天前快照
- controller/OnchainHolderController: REST CRUD + /api/onchain-holder/status
- templates/onchain-holder.html: 链状态卡片、添加任务表单、监控任务列表
- application.yml: 新增 onchain.eth-rpc / onchain.bsc-rpc 配置
- docs/onchain_holder.md: 功能设计文档

https://claude.ai/code/session_01PvZ1bcExuLwj3i5T5SJpBv