### PR TITLE
fix: 飞书定时报警 Top10 改为 Top5，review 资金费突变逻辑

### DIFF
--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/controller/ApiController.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/controller/ApiController.java
@@ -214,14 +214,14 @@ public class ApiController {
     }
     /**
      * GET /api/perps/rates?exchange=OKX
-     * 返回指定交易所最新费率 top10高 / top10低，供页面 AJAX 自动刷新。
+     * 返回指定交易所最新费率 top5高 / top5低，供页面 AJAX 自动刷新。
      */
     @GetMapping("/perps/rates")
     public Map<String, Object> perpRates(@RequestParam(defaultValue = "OKX") String exchange) {
         String ex = exchange.toUpperCase();
-        List<Map<String, Object>> high = perpService.getTop10High(ex).stream()
+        List<Map<String, Object>> high = perpService.getTop5High(ex).stream()
                 .map(ApiController::toRateMap).collect(Collectors.toList());
-        List<Map<String, Object>> low  = perpService.getTop10Low(ex).stream()
+        List<Map<String, Object>> low  = perpService.getTop5Low(ex).stream()
                 .map(ApiController::toRateMap).collect(Collectors.toList());
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("exchange",    ex);
@@ -235,7 +235,7 @@ public class ApiController {
 
     /**
      * POST /api/perps/report
-     * 立刻发送三所 Top10 飞书汇报。5 分钟内只能触发一次。
+     * 立刻发送三所 Top5 飞书汇报。5 分钟内只能触发一次。
      */
     @PostMapping("/perps/report")
     public Map<String, Object> perpReport() {

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/PerpInstrumentRepository.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/PerpInstrumentRepository.java
@@ -16,17 +16,17 @@ public interface PerpInstrumentRepository extends JpaRepository<PerpInstrument, 
 
     List<PerpInstrument> findByIsWatchedTrue();
 
-    /** Top 10 费率最高（DESC），仅 U本位（USDT/USD 结算） */
+    /** Top 5 费率最高（DESC），仅 U本位（USDT/USD 结算） */
     @Query("SELECT p FROM PerpInstrument p WHERE p.exchange = :exchange AND p.isActive = true " +
            "AND p.latestFundingRate IS NOT NULL AND UPPER(p.quoteCurrency) IN ('USDT','USD') " +
-           "ORDER BY p.latestFundingRate DESC LIMIT 10")
-    List<PerpInstrument> findTop10HighByExchange(@Param("exchange") String exchange);
+           "ORDER BY p.latestFundingRate DESC LIMIT 5")
+    List<PerpInstrument> findTop5HighByExchange(@Param("exchange") String exchange);
 
-    /** Top 10 费率最低（ASC），仅 U本位 */
+    /** Top 5 费率最低（ASC），仅 U本位 */
     @Query("SELECT p FROM PerpInstrument p WHERE p.exchange = :exchange AND p.isActive = true " +
            "AND p.latestFundingRate IS NOT NULL AND UPPER(p.quoteCurrency) IN ('USDT','USD') " +
-           "ORDER BY p.latestFundingRate ASC LIMIT 10")
-    List<PerpInstrument> findTop10LowByExchange(@Param("exchange") String exchange);
+           "ORDER BY p.latestFundingRate ASC LIMIT 5")
+    List<PerpInstrument> findTop5LowByExchange(@Param("exchange") String exchange);
 
     /** 固定展示：按 exchange + symbol 列表查（BTC/ETH 精确匹配） */
     @Query("SELECT p FROM PerpInstrument p WHERE p.exchange = :exchange AND p.symbol IN :symbols AND p.isActive = true")

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/PerpAlertService.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/PerpAlertService.java
@@ -84,7 +84,7 @@ public class PerpAlertService {
         return true;
     }
 
-    // ─── 构建并发送 Top10 报告 ────────────────────────────────────────
+    // ─── 构建并发送 Top5 报告 ────────────────────────────────────────
     private void sendReport() {
         if (alertUrl == null || alertUrl.isBlank()) {
             log.warn("⚠️ perp.alert-url 未配置，跳过飞书汇报");
@@ -102,16 +102,16 @@ public class PerpAlertService {
 
         for (String[] ex : exchanges) {
             String exch = ex[0], icon = ex[1];
-            List<PerpInstrument> high = perpService.getTop10High(exch);
-            List<PerpInstrument> low  = perpService.getTop10Low(exch);
+            List<PerpInstrument> high = perpService.getTop5High(exch);
+            List<PerpInstrument> low  = perpService.getTop5Low(exch);
             if (high.isEmpty() && low.isEmpty()) continue;
 
             sb.append("━━━━━━━━━━━━━━━━━━━━━━━━\n");
             sb.append(icon).append(" ").append(exch).append("\n");
 
-            sb.append("▲ Top10 最高\n");
+            sb.append("▲ Top5 最高\n");
             appendRates(sb, high);
-            sb.append("▼ Top10 最低\n");
+            sb.append("▼ Top5 最低\n");
             appendRates(sb, low);
         }
 

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/PerpService.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/PerpService.java
@@ -13,12 +13,12 @@ public class PerpService {
 
     private final PerpInstrumentRepository instrumentRepo;
 
-    public List<PerpInstrument> getTop10High(String exchange) {
-        return instrumentRepo.findTop10HighByExchange(exchange);
+    public List<PerpInstrument> getTop5High(String exchange) {
+        return instrumentRepo.findTop5HighByExchange(exchange);
     }
 
-    public List<PerpInstrument> getTop10Low(String exchange) {
-        return instrumentRepo.findTop10LowByExchange(exchange);
+    public List<PerpInstrument> getTop5Low(String exchange) {
+        return instrumentRepo.findTop5LowByExchange(exchange);
     }
 
     public long getInstrumentCount(String exchange) {


### PR DESCRIPTION
- PerpInstrumentRepository: LIMIT 10 → 5，方法名 findTop10 → findTop5
- PerpService: 方法名 getTop10High/Low → getTop5High/Low
- PerpAlertService: 调用方及飞书消息标题同步更新
- ApiController: 调用方注释同步更新
- 资金费突变逻辑 review 结论：逻辑正确，absCurr > absPrev 已准确表达"距0越来越远"，无需修改

https://claude.ai/code/session_01RC74EHMCVJkRJ5uurif1R7