### PR TITLE
fix: OnchainWatch.tokenDecimals 加 columnDefinition=TINYINT 匹配 DB

### DIFF
--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/model/OnchainWatch.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/model/OnchainWatch.java
@@ -32,7 +32,7 @@ public class OnchainWatch {
     private String network;
 
     /** ERC20 小数位，首次查链获取，默认 18 */
-    @Column(name = "token_decimals", nullable = false)
+    @Column(name = "token_decimals", nullable = false, columnDefinition = "TINYINT")
     private int tokenDecimals = 18;
 
     /** TOKEN = 按代币数量比对；USD = 按折算美元比对 */


### PR DESCRIPTION
Hibernate schema validate 要求列类型一致，DB 建表用 TINYINT，
实体 int 默认映射 INTEGER，加 columnDefinition 消除类型不匹配

https://claude.ai/code/session_01RC74EHMCVJkRJ5uurif1R7