### PR TITLE
fix: perps页面恢复Top10，飞书报警保持Top5

### DIFF
--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/controller/ApiController.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/controller/ApiController.java
@@ -219,9 +219,9 @@ public class ApiController {
     @GetMapping("/perps/rates")
     public Map<String, Object> perpRates(@RequestParam(defaultValue = "OKX") String exchange) {
         String ex = exchange.toUpperCase();
-        List<Map<String, Object>> high = perpService.getTop5High(ex).stream()
+        List<Map<String, Object>> high = perpService.getTop10High(ex).stream()
                 .map(ApiController::toRateMap).collect(Collectors.toList());
-        List<Map<String, Object>> low  = perpService.getTop5Low(ex).stream()
+        List<Map<String, Object>> low  = perpService.getTop10Low(ex).stream()
                 .map(ApiController::toRateMap).collect(Collectors.toList());
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("exchange",    ex);

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/PerpInstrumentRepository.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/PerpInstrumentRepository.java
@@ -16,17 +16,17 @@ public interface PerpInstrumentRepository extends JpaRepository<PerpInstrument, 
 
     List<PerpInstrument> findByIsWatchedTrue();
 
-    /** Top 5 费率最高（DESC），仅 U本位（USDT/USD 结算） */
+    /** Top 10 费率最高（DESC），仅 U本位（USDT/USD 结算） */
     @Query("SELECT p FROM PerpInstrument p WHERE p.exchange = :exchange AND p.isActive = true " +
            "AND p.latestFundingRate IS NOT NULL AND UPPER(p.quoteCurrency) IN ('USDT','USD') " +
-           "ORDER BY p.latestFundingRate DESC LIMIT 5")
-    List<PerpInstrument> findTop5HighByExchange(@Param("exchange") String exchange);
+           "ORDER BY p.latestFundingRate DESC LIMIT 10")
+    List<PerpInstrument> findTop10HighByExchange(@Param("exchange") String exchange);
 
-    /** Top 5 费率最低（ASC），仅 U本位 */
+    /** Top 10 费率最低（ASC），仅 U本位 */
     @Query("SELECT p FROM PerpInstrument p WHERE p.exchange = :exchange AND p.isActive = true " +
            "AND p.latestFundingRate IS NOT NULL AND UPPER(p.quoteCurrency) IN ('USDT','USD') " +
-           "ORDER BY p.latestFundingRate ASC LIMIT 5")
-    List<PerpInstrument> findTop5LowByExchange(@Param("exchange") String exchange);
+           "ORDER BY p.latestFundingRate ASC LIMIT 10")
+    List<PerpInstrument> findTop10LowByExchange(@Param("exchange") String exchange);
 
     /** 固定展示：按 exchange + symbol 列表查（BTC/ETH 精确匹配） */
     @Query("SELECT p FROM PerpInstrument p WHERE p.exchange = :exchange AND p.symbol IN :symbols AND p.isActive = true")

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/PerpAlertService.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/PerpAlertService.java
@@ -84,7 +84,7 @@ public class PerpAlertService {
         return true;
     }
 
-    // ─── 构建并发送 Top5 报告 ────────────────────────────────────────
+    // ─── 构建并发送 Top5 飞书报告（页面仍展示 Top10）────────────────
     private void sendReport() {
         if (alertUrl == null || alertUrl.isBlank()) {
             log.warn("⚠️ perp.alert-url 未配置，跳过飞书汇报");
@@ -102,8 +102,8 @@ public class PerpAlertService {
 
         for (String[] ex : exchanges) {
             String exch = ex[0], icon = ex[1];
-            List<PerpInstrument> high = perpService.getTop5High(exch);
-            List<PerpInstrument> low  = perpService.getTop5Low(exch);
+            List<PerpInstrument> high = top5(perpService.getTop10High(exch));
+            List<PerpInstrument> low  = top5(perpService.getTop10Low(exch));
             if (high.isEmpty() && low.isEmpty()) continue;
 
             sb.append("━━━━━━━━━━━━━━━━━━━━━━━━\n");
@@ -117,6 +117,10 @@ public class PerpAlertService {
 
         sendFeishu(sb.toString());
         log.info("📤 Perps 飞书汇报已发送");
+    }
+
+    private static List<PerpInstrument> top5(List<PerpInstrument> list) {
+        return list.size() <= 5 ? list : list.subList(0, 5);
     }
 
     private void appendRates(StringBuilder sb, List<PerpInstrument> list) {

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/PerpService.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/PerpService.java
@@ -13,12 +13,12 @@ public class PerpService {
 
     private final PerpInstrumentRepository instrumentRepo;
 
-    public List<PerpInstrument> getTop5High(String exchange) {
-        return instrumentRepo.findTop5HighByExchange(exchange);
+    public List<PerpInstrument> getTop10High(String exchange) {
+        return instrumentRepo.findTop10HighByExchange(exchange);
     }
 
-    public List<PerpInstrument> getTop5Low(String exchange) {
-        return instrumentRepo.findTop5LowByExchange(exchange);
+    public List<PerpInstrument> getTop10Low(String exchange) {
+        return instrumentRepo.findTop10LowByExchange(exchange);
     }
 
     public long getInstrumentCount(String exchange) {


### PR DESCRIPTION
- Repository/Service/ApiController 恢复 findTop10/getTop10 供页面展示
- PerpAlertService 取 Top10 后截取前5条发送飞书，标签保持"Top5 最高/最低"
- 新增 top5() 辅助方法做 subList 截取

https://claude.ai/code/session_01RC74EHMCVJkRJ5uurif1R7