### PR TITLE
fix: 合约行情三处修复

### DIFF
--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/BinanceTickerJob.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/BinanceTickerJob.java
@@ -2,6 +2,7 @@ package com.deanrobin.aios.dashboard.job;
 
 import com.deanrobin.aios.dashboard.model.BinanceTicker;
 import com.deanrobin.aios.dashboard.repository.BinanceTickerRepository;
+import com.deanrobin.aios.dashboard.repository.PerpInstrumentRepository;
 import com.deanrobin.aios.dashboard.service.PerpAlertService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -15,6 +16,8 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * 每分钟拉取 Binance U本位永续合约 24h 行情，upsert 到 binance_ticker 表。
@@ -35,9 +38,10 @@ public class BinanceTickerJob {
     /** 成交额报警阈值：5000w USDT */
     private static final BigDecimal VOLUME_ALERT_THRESHOLD = new BigDecimal("50000000");
 
-    private final BinanceTickerRepository tickerRepo;
-    private final PerpAlertService        perpAlertService;
-    private final WebClient.Builder       webClientBuilder;
+    private final BinanceTickerRepository  tickerRepo;
+    private final PerpInstrumentRepository instrumentRepo;
+    private final PerpAlertService         perpAlertService;
+    private final WebClient.Builder        webClientBuilder;
 
     // initialDelay 错开其他 Binance job（BinancePerpJob initialDelay 20s/90s）
     @Scheduled(initialDelay = 30_000, fixedDelay = 60_000)
@@ -45,14 +49,21 @@ public class BinanceTickerJob {
         List<Map<String, Object>> raw = fetchFromBinance();
         if (raw.isEmpty()) return;
 
+        // 取 perp_instrument 中 BINANCE 在交易的品种，过滤掉已下线合约
+        Set<String> activeSymbols = instrumentRepo.findByExchangeAndIsActiveTrue("BINANCE")
+                .stream()
+                .map(p -> p.getSymbol())
+                .collect(Collectors.toSet());
+
         LocalDateTime now   = LocalDateTime.now();
         int upserted = 0;
 
         for (Map<String, Object> item : raw) {
             String symbol = str(item, "symbol");
             if (symbol.isBlank()) continue;
-            // 只保留 USDT 结算
+            // 只保留 USDT 结算 且 perp_instrument 中存在的活跃合约
             if (!symbol.endsWith("USDT")) continue;
+            if (!activeSymbols.contains(symbol)) continue;
 
             BigDecimal lastPrice      = decimal(item, "lastPrice");
             BigDecimal priceChangePct = decimal(item, "priceChangePercent");

--- a/dashboard/src/main/resources/templates/ticker.html
+++ b/dashboard/src/main/resources/templates/ticker.html
@@ -27,11 +27,18 @@
 }
 .sort-btn:hover:not(.active) { background: #f0f4ff; }
 
+.ticker-table  { table-layout: fixed; width: 100%; }
 .ticker-table th { font-size: .73rem; color: var(--t3); font-weight: 600; white-space: nowrap; }
 .ticker-table td { font-size: .83rem; vertical-align: middle; }
-.ticker-rank    { color: var(--t3); font-size: .75rem; width: 28px; }
-.ticker-symbol  { font-weight: 700; color: var(--t1); }
-.ticker-base    { font-size: .72rem; color: var(--t3); margin-left: 4px; }
+.ticker-col-rank   { width: 36px; }
+.ticker-col-symbol { width: 130px; }
+.ticker-col-price  { width: 120px; }
+.ticker-col-chg    { width: 90px; }
+.ticker-col-vol    { width: 120px; }
+.ticker-col-cnt    { width: 100px; }
+.ticker-rank   { color: var(--t3); font-size: .75rem; }
+.ticker-symbol { font-weight: 700; color: var(--t1); }
+.ticker-base   { font-size: .72rem; color: var(--t3); margin-left: 4px; }
 </style>
 
 <!-- ── 页头 ────────────────────────────────────────────────────── -->
@@ -55,6 +62,14 @@
 <div class="card">
     <div class="card-body p-0">
         <table class="table table-hover mb-0 ticker-table">
+            <colgroup>
+                <col class="ticker-col-rank">
+                <col class="ticker-col-symbol">
+                <col class="ticker-col-price">
+                <col class="ticker-col-chg">
+                <col class="ticker-col-vol">
+                <col class="ticker-col-cnt">
+            </colgroup>
             <thead>
                 <tr>
                     <th class="ps-3">#</th>
@@ -106,12 +121,13 @@ function renderTable(rows) {
         return;
     }
     tb.innerHTML = rows.map((r, i) => {
-        const pct     = parseFloat(r.changePct) || 0;
-        const pctCls  = pct > 0 ? 'chg-pos' : pct < 0 ? 'chg-neg' : 'chg-zero';
-        const pctStr  = (pct >= 0 ? '+' : '') + pct.toFixed(2) + '%';
-        const price   = fmtPrice(r.price);
-        const vol     = fmtVol(r.quoteVolume);
-        const cnt     = r.tradeCount != null ? Number(r.tradeCount).toLocaleString() : '—';
+        const pct    = parseFloat(r.changePct) || 0;
+        const color  = pct > 0 ? 'var(--green)' : pct < 0 ? 'var(--red)' : 'var(--t3)';
+        const weight = pct === 0 ? '600' : '700';
+        const pctStr = (pct > 0 ? '+' : '') + pct.toFixed(2) + '%';
+        const price  = fmtPrice(r.price);
+        const vol    = fmtVol(r.quoteVolume);
+        const cnt    = r.tradeCount != null ? Number(r.tradeCount).toLocaleString() : '—';
         return `<tr>
             <td class="ps-3 ticker-rank">${i + 1}</td>
             <td>
@@ -119,7 +135,7 @@ function renderTable(rows) {
                 <span class="ticker-base">${r.symbol}</span>
             </td>
             <td class="text-end mono">${price}</td>
-            <td class="text-end ${pctCls}">${pctStr}</td>
+            <td class="text-end"><span style="font-family:'JetBrains Mono';color:${color};font-weight:${weight}">${pctStr}</span></td>
             <td class="text-end mono">${vol}</td>
             <td class="text-end pe-3 text-muted" style="font-size:.78rem">${cnt}</td>
         </tr>`;


### PR DESCRIPTION
1. BinanceTickerJob 过滤无效合约：upsert 前与 perp_instrument 活跃 品种做 Set 交集，过滤掉 ALPACA/A2Z 等已下线或非永续合约
2. ticker.html 列宽：table-layout:fixed + colgroup 固定各列宽度， 消除合约列和最新价列之间的大间隔
3. ticker.html 颜色：24h涨跌用 inline style 直接写 var(--green)/ var(--red)，避免 Bootstrap td 样式覆盖；涨幅绿色、跌幅红色

https://claude.ai/code/session_01RC74EHMCVJkRJ5uurif1R7