### PR TITLE
fix: 过滤非TRADING合约 + 自动标记下线品种

### DIFF
--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/BinancePerpJob.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/BinancePerpJob.java
@@ -17,6 +17,8 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.Map;
 
 /**
@@ -88,6 +90,23 @@ public class BinancePerpJob {
             log.info("🆕 Binance 新增永续合约 {} 个: {}", newCount, newSymbols);
             triggerAlert(newSymbols.size(), String.join(",", newSymbols.subList(0, Math.min(3, newSymbols.size()))));
         }
+
+        // 将本次未出现的品种标记为下线（status 不再是 TRADING）
+        Set<String> returnedSymbols = instruments.stream()
+                .map(i -> String.valueOf(i.getOrDefault("symbol", "")))
+                .filter(s -> !s.isBlank())
+                .collect(Collectors.toSet());
+        int deactivated = 0;
+        for (PerpInstrument pi : instrumentRepo.findByExchangeAndIsActiveTrue(EXCHANGE)) {
+            if (!returnedSymbols.contains(pi.getSymbol())) {
+                pi.setIsActive(false);
+                pi.setLastSeenAt(now);
+                instrumentRepo.save(pi);
+                deactivated++;
+                log.info("⬇️ Binance 合约下线: {}", pi.getSymbol());
+            }
+        }
+        if (deactivated > 0) log.info("⬇️ Binance 共下线 {} 个合约", deactivated);
     }
 
     // ═══ 全量资金费率（每 5 min，initialDelay 90s）═══════════════════

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/PerpApiClient.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/PerpApiClient.java
@@ -127,7 +127,8 @@ public class PerpApiClient {
             List<Map<String, Object>> result = new ArrayList<>();
             for (Object item : list) {
                 if (item instanceof Map<?, ?> m) {
-                    if ("PERPETUAL".equals(m.get("contractType"))) {
+                    if ("PERPETUAL".equals(m.get("contractType"))
+                            && "TRADING".equals(m.get("status"))) {
                         result.add((Map<String, Object>) m);
                     }
                 }


### PR DESCRIPTION
- PerpApiClient: fetchBinanceInstruments 增加 status=TRADING 过滤， 排除 SETTLING/CLOSED 等非活跃状态（如 ALPACA、A2Z）
- BinancePerpJob.syncInstruments: 每次同步后将未出现在返回列表中的 active 品种标记为 is_active=false，确保 perp_instrument 表及时清理

https://claude.ai/code/session_01RC74EHMCVJkRJ5uurif1R7