### PR TITLE
feat: 成交量报警黑名单 + 1H限报一次

### DIFF
--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/model/TickerAlertBlacklist.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/model/TickerAlertBlacklist.java
@@ -1,0 +1,25 @@
+package com.deanrobin.aios.dashboard.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "ticker_alert_blacklist")
+public class TickerAlertBlacklist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String symbol;
+
+    @Column(length = 200)
+    private String note;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+}

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/TickerAlertBlacklistRepository.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/TickerAlertBlacklistRepository.java
@@ -1,0 +1,13 @@
+package com.deanrobin.aios.dashboard.repository;
+
+import com.deanrobin.aios.dashboard.model.TickerAlertBlacklist;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Set;
+
+public interface TickerAlertBlacklistRepository extends JpaRepository<TickerAlertBlacklist, Long> {
+
+    @Query("SELECT b.symbol FROM TickerAlertBlacklist b")
+    Set<String> findAllSymbols();
+}

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/PerpAlertService.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/PerpAlertService.java
@@ -4,6 +4,7 @@ import com.deanrobin.aios.dashboard.model.PerpFundingRate;
 import com.deanrobin.aios.dashboard.model.PerpInstrument;
 import com.deanrobin.aios.dashboard.repository.PerpFundingRateRepository;
 import com.deanrobin.aios.dashboard.repository.PerpInstrumentRepository;
+import com.deanrobin.aios.dashboard.repository.TickerAlertBlacklistRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Value;
@@ -46,10 +47,11 @@ public class PerpAlertService {
     private static final DateTimeFormatter FMT = DateTimeFormatter.ofPattern("MM-dd HH:mm");
     private static final ZoneId CST = ZoneId.of("Asia/Shanghai");
 
-    private final PerpService               perpService;
-    private final PerpInstrumentRepository  instrumentRepo;
-    private final PerpFundingRateRepository fundingRateRepo;
-    private final WebClient.Builder         webClientBuilder;
+    private final PerpService                      perpService;
+    private final PerpInstrumentRepository         instrumentRepo;
+    private final PerpFundingRateRepository        fundingRateRepo;
+    private final TickerAlertBlacklistRepository   blacklistRepo;
+    private final WebClient.Builder                webClientBuilder;
 
     @Value("${perp.alert-url:}")
     private String alertUrl;
@@ -57,8 +59,21 @@ public class PerpAlertService {
     /** spike 报警冷却：key = "EXCHANGE:SYMBOL"，value = 上次报警时间戳 */
     private final ConcurrentHashMap<String, Long> spikeCooldown = new ConcurrentHashMap<>();
 
-    /** 成交量报警冷却：key = symbol，value = 上次报警时间戳 */
+    /** 成交量报警冷却：key = symbol，value = 上次报警时间戳（1H 最多一次） */
     private final ConcurrentHashMap<String, Long> volumeCooldown = new ConcurrentHashMap<>();
+
+    /** 黑名单缓存，每 5 分钟从 DB 刷新一次 */
+    private volatile Set<String> blacklistCache = Set.of();
+
+    @Scheduled(initialDelay = 0, fixedDelay = 300_000)
+    public void refreshBlacklist() {
+        try {
+            blacklistCache = blacklistRepo.findAllSymbols();
+            log.debug("🔕 成交量报警黑名单已刷新，共 {} 个", blacklistCache.size());
+        } catch (Exception e) {
+            log.warn("⚠️ 黑名单刷新失败: {}", e.getMessage());
+        }
+    }
 
     /** 手动汇报冷却 */
     private final AtomicLong lastManualReport = new AtomicLong(0);
@@ -213,6 +228,9 @@ public class PerpAlertService {
      */
     public void checkVolumeAlert(String symbol, java.math.BigDecimal quoteVolume) {
         if (alertUrl == null || alertUrl.isBlank()) return;
+        // 黑名单过滤
+        if (blacklistCache.contains(symbol)) return;
+        // 1H 冷却
         String key = "VOL:" + symbol;
         long last = volumeCooldown.getOrDefault(key, 0L);
         if (System.currentTimeMillis() - last < SPIKE_COOLDOWN_MS) return;
@@ -222,7 +240,7 @@ public class PerpAlertService {
                 "🔥 合约成交量异动\n合约: %s\n24h成交额: %.0f USDT (%.1f亿)",
                 symbol, vol, vol / 1_0000_0000.0);
         sendFeishu(text);
-        log.info("🔥 成交量报警 | {} | 24h成交额={:.0f} USDT", symbol, vol);
+        log.info("🔥 成交量报警 | {} | 24h成交额={} USDT", symbol, String.format("%.0f", vol));
     }
 
     // ─── 飞书发送 ────────────────────────────────────────────────────

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -154,6 +154,23 @@ CREATE TABLE IF NOT EXISTS binance_ticker (
     INDEX idx_price_change (price_change_pct)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+-- ── 合约成交量报警黑名单（命中则不报警）────────────────────────────────
+CREATE TABLE IF NOT EXISTS ticker_alert_blacklist (
+    id         BIGINT       AUTO_INCREMENT PRIMARY KEY,
+    symbol     VARCHAR(50)  NOT NULL COMMENT '合约交易对，如 BTCUSDT',
+    note       VARCHAR(200)          COMMENT '备注',
+    created_at DATETIME     DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_symbol (symbol)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT IGNORE INTO ticker_alert_blacklist (symbol, note) VALUES
+    ('BTCUSDT',  '主流币，24h量常态超阈值'),
+    ('ETHUSDT',  '主流币，24h量常态超阈值'),
+    ('BNBUSDT',  '主流币，24h量常态超阈值'),
+    ('SOLUSDT',  '主流币，24h量常态超阈值'),
+    ('XRPUSDT',  '主流币，24h量常态超阈值'),
+    ('DOGEUSDT', '主流币，24h量常态超阈值');
+
 -- ── 链上持仓余额快照表 ──────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS onchain_holder_snapshot (
     id             BIGINT AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
- db/schema.sql: 新增 ticker_alert_blacklist 表，INSERT IGNORE 初始化 BTC/ETH/BNB/SOL/XRP/DOGE 六个主流币（后续可手动 INSERT 追加）
- TickerAlertBlacklist entity + TickerAlertBlacklistRepository
- PerpAlertService:
  - 注入黑名单 repo，每 5 分钟刷新内存缓存 blacklistCache
  - checkVolumeAlert 先检查黑名单，命中直接跳过
  - 1H 冷却已有（SPIKE_COOLDOWN_MS），顺手修复 log 格式 {:.0f} → {}

https://claude.ai/code/session_01RC74EHMCVJkRJ5uurif1R7