### PR TITLE
fix: 资金费率突变报警也走黑名单过滤

### DIFF
--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/PerpAlertService.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/PerpAlertService.java
@@ -182,10 +182,11 @@ public class PerpAlertService {
                         (a, b) -> b   // 保留后一条
                 ));
 
-        // 与当前 latest_funding_rate 对比
+        // 与当前 latest_funding_rate 对比（仅 active 品种，且跳过黑名单）
         List<PerpInstrument> current = instrumentRepo.findByExchangeAndIsActiveTrue(exchange);
         for (PerpInstrument inst : current) {
             if (inst.getLatestFundingRate() == null) continue;
+            if (blacklistCache.contains(inst.getSymbol())) continue;   // 黑名单跳过
             BigDecimal prevBD = prev15.get(inst.getSymbol());
             if (prevBD == null) continue;
 


### PR DESCRIPTION
checkSpikes 对每个 active 品种检测前先判断 blacklistCache，
命中黑名单（BTC/ETH 等）直接跳过，不触发飞书报警

https://claude.ai/code/session_01RC74EHMCVJkRJ5uurif1R7