### PR TITLE
perf: optimize MySQL load — indexes, slow queries, job cleanup

### DIFF
--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/PerpCleanupJob.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/PerpCleanupJob.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
  * Perps 数据清理 Job，两个定时任务：
  *
  * 00:35 清理旧快照：
- *   - perp_funding_rate    → 保留 5 天
+ *   - perp_funding_rate    → 保留 2 天（写入量大：~650条/5min，2天≈374K行；spike检测窗口最长1h，2天足够）
  *   - perp_open_interest   → 保留 7 天
  *
  * 01:15 清理特别关注快照：
@@ -34,14 +34,14 @@ public class PerpCleanupJob {
     /** 00:35 清理资金费率 + OI 快照 */
     @Scheduled(cron = "0 35 0 * * *", zone = "Asia/Shanghai")
     public void cleanOldSnapshots() {
-        // ── 资金费率：保留 5 天 ──
-        LocalDateTime frBefore = LocalDateTime.now().minusDays(5);
+        // ── 资金费率：保留 2 天（原 5 天，写入量大缩短以控制表行数）──
+        LocalDateTime frBefore = LocalDateTime.now().minusDays(2);
         int frTotal = 0, frDeleted;
         do {
             frDeleted = fundingRateRepo.deleteOldSnapshots(frBefore);
             frTotal  += frDeleted;
         } while (frDeleted == 500);
-        if (frTotal > 0) log.info("🧹 资金费率快照清理 {} 条（5天前）", frTotal);
+        if (frTotal > 0) log.info("🧹 资金费率快照清理 {} 条（2天前）", frTotal);
 
         // ── 持仓量：保留 7 天 ──
         LocalDateTime oiBefore = LocalDateTime.now().minusDays(7);

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/PriceFetchJob.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/PriceFetchJob.java
@@ -10,8 +10,10 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * 每 10 秒从 OKX 公开市场 API 拉 BTC/ETH/BNB/SOL 价格及 24h 交易量，写入 price_ticker 表。
@@ -36,7 +38,14 @@ public class PriceFetchJob {
     @Scheduled(initialDelay = 5_000, fixedDelay = 10_000)
     public void fetchPrices() {
         WebClient client = webClientBuilder.baseUrl("https://www.okx.com").build();
-        int updated = 0;
+
+        // 一次批量加载所有已有 ticker，减少 DB 查询：5×SELECT → 1×SELECT
+        Map<String, PriceTicker> existing = priceRepo.findAll()
+                .stream().collect(Collectors.toMap(PriceTicker::getSymbol, t -> t));
+
+        List<PriceTicker> toSave = new ArrayList<>();
+        LocalDateTime now = LocalDateTime.now();
+
         for (String[] pair : TARGETS) {
             String symbol = pair[0];
             String instId = pair[1];
@@ -64,20 +73,23 @@ public class PriceFetchJob {
                         .setScale(4, java.math.RoundingMode.HALF_UP);
                 }
 
-                PriceTicker pt = priceRepo.findBySymbol(symbol).orElseGet(() -> {
-                    PriceTicker n = new PriceTicker(); n.setSymbol(symbol); return n;
-                });
+                PriceTicker pt = existing.getOrDefault(symbol, new PriceTicker());
+                if (pt.getSymbol() == null) pt.setSymbol(symbol);
                 pt.setPriceUsd(price);
                 pt.setChange24h(change24h);
                 pt.setVolume24h(vol24h);
-                pt.setUpdatedAt(LocalDateTime.now());
-                priceRepo.save(pt);
-                updated++;
+                pt.setUpdatedAt(now);
+                toSave.add(pt);
             } catch (Exception e) {
                 log.warn("⚠️ 价格拉取失败 {}: {}", symbol, e.getMessage());
             }
         }
-        if (updated > 0) log.debug("💹 价格已更新 {} 个代币", updated);
+
+        // 5×save → 1×saveAll，减少 DB round-trip
+        if (!toSave.isEmpty()) {
+            priceRepo.saveAll(toSave);
+            log.debug("💹 价格已更新 {} 个代币", toSave.size());
+        }
     }
 
     private BigDecimal parseBD(Object obj) {

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/SignalCleanupJob.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/SignalCleanupJob.java
@@ -1,0 +1,56 @@
+package com.deanrobin.aios.dashboard.job;
+
+import com.deanrobin.aios.dashboard.repository.PumpMarketCapSnapshotRepository;
+import com.deanrobin.aios.dashboard.repository.SmartMoneySignalRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+/**
+ * 每天 01:30 清理两张无过期机制的表，防止数据无限增长导致慢查询。
+ *
+ * <ul>
+ *   <li>smart_money_signal   — 保留最近 30 天（信号是时效性数据，旧信号无价值）</li>
+ *   <li>pump_market_cap_snapshot — 保留最近 30 天（快照仅用于 survivors 历史查看）</li>
+ * </ul>
+ *
+ * 均分批删除（LIMIT 500），防止长事务锁表。
+ * ⚠️ 不加 @Transactional（符合 CLAUDE.md 约定）
+ */
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class SignalCleanupJob {
+
+    private final SmartMoneySignalRepository    signalRepo;
+    private final PumpMarketCapSnapshotRepository snapshotRepo;
+
+    @Scheduled(cron = "0 30 1 * * *", zone = "Asia/Shanghai")
+    public void clean() {
+        LocalDateTime cutoff = LocalDateTime.now().minusDays(30);
+
+        // ── smart_money_signal（30天前）──────────────────────────────
+        int signalTotal = 0, deleted;
+        do {
+            deleted     = signalRepo.deleteOlderThan(cutoff);
+            signalTotal += deleted;
+        } while (deleted == 500);
+
+        // ── pump_market_cap_snapshot（30天前）────────────────────────
+        int snapTotal = 0;
+        do {
+            deleted   = snapshotRepo.deleteOlderThan(cutoff);
+            snapTotal += deleted;
+        } while (deleted == 500);
+
+        if (signalTotal + snapTotal > 0) {
+            log.info("🧹 SignalCleanupJob 完成 | signal={} snapshot={} (30天前数据)",
+                    signalTotal, snapTotal);
+        } else {
+            log.debug("🧹 SignalCleanupJob 无需清理");
+        }
+    }
+}

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/SignalFetchJob.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/job/SignalFetchJob.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -27,6 +28,14 @@ import java.util.concurrent.TimeUnit;
 public class SignalFetchJob {
 
     private static final String SIGNAL_PATH = "/api/v6/dex/market/signal/list";
+
+    /**
+     * 内存缓存：记录已写入 DB 的钱包 key（chain:address）及写入时间戳（ms）。
+     * 避免 SignalFetchJob 每 10s 对每个 trigger_wallet 都打 existsByAddressAndChainIndex 查询。
+     * TTL = 60 分钟：钱包一旦写入 DB 就不需要再查，60 分钟后自动失效（防无限增长）。
+     */
+    private static final long WALLET_CACHE_TTL_MS = 60 * 60 * 1000L; // 60 min
+    private final Map<String, Long> walletSeenCache = new ConcurrentHashMap<>();
 
     private final OkxApiClient             okxClient;
     private final SmartMoneyJobConfig      jobConfig;
@@ -207,18 +216,32 @@ public class SignalFetchJob {
         Object raw = sig.get("triggerWalletAddress");
         if (raw == null) return;
         String[] parts = String.valueOf(raw).split(",");
+        long now = System.currentTimeMillis();
         for (String addr : parts) {
             addr = addr.strip();
             if (addr.length() >= 20) { // SOL 地址 ~44 字符, EVM ~42
                 String key = chain + ":" + addr.toLowerCase();
                 if (newWallets.add(key)) {
-                    saveWalletIfAbsent(addr, chain);
+                    saveWalletIfAbsent(addr, chain, key, now);
                 }
             }
         }
+        // 定期清理过期缓存条目（简单惰性清理：本轮处理时顺手清一次）
+        if (walletSeenCache.size() > 5000) {
+            walletSeenCache.entrySet().removeIf(e -> now - e.getValue() > WALLET_CACHE_TTL_MS);
+        }
     }
 
-    private void saveWalletIfAbsent(String address, String chain) {
+    /**
+     * 先查内存缓存，命中则跳过 DB 查询。
+     * 未命中才执行 existsByAddressAndChainIndex，确认不存在后写入并更新缓存。
+     * 每 10s 被调用，原来每次最多 40 个 DB 查询，现在热路径 0 次。
+     */
+    private void saveWalletIfAbsent(String address, String chain, String cacheKey, long nowMs) {
+        Long cachedAt = walletSeenCache.get(cacheKey);
+        if (cachedAt != null && nowMs - cachedAt < WALLET_CACHE_TTL_MS) {
+            return; // 缓存命中，跳过 DB 查询
+        }
         if (!walletRepo.existsByAddressAndChainIndex(address, chain)) {
             SmartMoneyWallet w = new SmartMoneyWallet();
             w.setAddress(address);
@@ -231,6 +254,8 @@ public class SignalFetchJob {
             w.setUpdatedAt(LocalDateTime.now());
             walletRepo.save(w);
         }
+        // 无论是否新写入，都记入缓存（已在 DB 的也不必再查）
+        walletSeenCache.put(cacheKey, nowMs);
     }
 
     private BigDecimal toBd(Object v) {

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/PumpMarketCapSnapshotRepository.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/PumpMarketCapSnapshotRepository.java
@@ -2,13 +2,23 @@ package com.deanrobin.aios.dashboard.repository;
 
 import com.deanrobin.aios.dashboard.model.PumpMarketCapSnapshot;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PumpMarketCapSnapshotRepository extends JpaRepository<PumpMarketCapSnapshot, Long> {
 
-    /** 查某个 mint 的历史快照，按时间倒序最多 N 条 */
+    /** 查某个 mint 的历史快照，按时间倒序最多 N 条。配合 idx_mint_checked_at 索引。 */
     @Query(value = "SELECT * FROM pump_market_cap_snapshot WHERE mint = :mint ORDER BY checked_at DESC LIMIT :limit", nativeQuery = true)
     List<PumpMarketCapSnapshot> findByMintRecent(String mint, int limit);
+
+    /** 清理 N 天前的快照（SignalCleanupJob 每日调用，分批删除防长事务） */
+    @Modifying
+    @Transactional
+    @Query(value = "DELETE FROM pump_market_cap_snapshot WHERE checked_at < :before LIMIT 500", nativeQuery = true)
+    int deleteOlderThan(@Param("before") LocalDateTime before);
 }

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/PumpTokenRepository.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/PumpTokenRepository.java
@@ -47,12 +47,15 @@ public interface PumpTokenRepository extends JpaRepository<PumpToken, Long> {
     @Query("SELECT t FROM PumpToken t WHERE t.status = 'survived' ORDER BY t.currentMarketCap DESC NULLS LAST")
     List<PumpToken> findSurvivors();
 
-    /** 取 SOL 当前价格（USD） */
-    @Query(value = "SELECT price_usd FROM price_ticker WHERE symbol='SOL' ORDER BY updated_at DESC LIMIT 1", nativeQuery = true)
+    /**
+     * 取 SOL 当前价格（USD）。
+     * symbol 是 UNIQUE KEY，ORDER BY updated_at 无意义且浪费排序开销，去掉。
+     */
+    @Query(value = "SELECT price_usd FROM price_ticker WHERE symbol='SOL' LIMIT 1", nativeQuery = true)
     java.math.BigDecimal findSolPrice();
 
-    /** 取 BNB 当前价格（USD） */
-    @Query(value = "SELECT price_usd FROM price_ticker WHERE symbol='BNB' ORDER BY updated_at DESC LIMIT 1", nativeQuery = true)
+    /** 取 BNB 当前价格（USD）。同上，去掉无用 ORDER BY。 */
+    @Query(value = "SELECT price_usd FROM price_ticker WHERE symbol='BNB' LIMIT 1", nativeQuery = true)
     java.math.BigDecimal findBnbPrice();
 
     // 保留最近 N 条，删除旧数据

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/SmartMoneySignalRepository.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/SmartMoneySignalRepository.java
@@ -5,18 +5,49 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface SmartMoneySignalRepository extends JpaRepository<SmartMoneySignal, Long> {
 
-    @Query(value = "SELECT * FROM smart_money_signal WHERE (market_cap_usd IS NULL OR market_cap_usd=0 OR (market_cap_usd>=10000 AND amount_usd/market_cap_usd<=0.5)) ORDER BY signal_time DESC LIMIT :limit", nativeQuery = true)
+    /**
+     * 查最近信号（首页 / signals 页）。
+     * 加 signal_time > 7天 时间过滤，配合 idx_signal_time 索引走范围扫描，
+     * 避免全表扫描（表无限增长时 OR + 表达式条件会导致慢查询）。
+     */
+    @Query(value = "SELECT * FROM smart_money_signal" +
+                   " WHERE signal_time > DATE_SUB(NOW(), INTERVAL 7 DAY)" +
+                   " AND (market_cap_usd IS NULL OR market_cap_usd=0" +
+                   "      OR (market_cap_usd>=10000 AND amount_usd/market_cap_usd<=0.5))" +
+                   " ORDER BY signal_time DESC LIMIT :limit", nativeQuery = true)
     List<SmartMoneySignal> findRecent(@Param("limit") int limit);
 
-    @Query(value = "SELECT * FROM smart_money_signal WHERE chain_index=:chain AND (market_cap_usd IS NULL OR market_cap_usd=0 OR (market_cap_usd>=10000 AND amount_usd/market_cap_usd<=0.5)) ORDER BY signal_time DESC LIMIT :limit", nativeQuery = true)
+    @Query(value = "SELECT * FROM smart_money_signal" +
+                   " WHERE chain_index=:chain" +
+                   " AND signal_time > DATE_SUB(NOW(), INTERVAL 7 DAY)" +
+                   " AND (market_cap_usd IS NULL OR market_cap_usd=0" +
+                   "      OR (market_cap_usd>=10000 AND amount_usd/market_cap_usd<=0.5))" +
+                   " ORDER BY signal_time DESC LIMIT :limit", nativeQuery = true)
     List<SmartMoneySignal> findRecentByChain(@Param("chain") String chain, @Param("limit") int limit);
 
-    /** 查最近一条同链同 token 记录（用于判断是否需要更新） */
-    @Query(value = "SELECT * FROM smart_money_signal WHERE chain_index=:chain AND token_address=:addr AND wallet_type=:wt ORDER BY signal_time DESC LIMIT 1", nativeQuery = true)
-    java.util.Optional<SmartMoneySignal> findLatest(@Param("chain") String chain, @Param("addr") String addr, @Param("wt") String wt);
+    /**
+     * 查最近一条同链同 token 记录（用于判断是否需要更新）。
+     * 配合 idx_chain_token_wt_time(chain_index, token_address, wallet_type, signal_time) 索引，
+     * 直接走索引尾部取最大 signal_time，无需排序。每 10s 被调用 40+ 次，索引至关重要。
+     */
+    @Query(value = "SELECT * FROM smart_money_signal" +
+                   " WHERE chain_index=:chain AND token_address=:addr AND wallet_type=:wt" +
+                   " ORDER BY signal_time DESC LIMIT 1", nativeQuery = true)
+    java.util.Optional<SmartMoneySignal> findLatest(@Param("chain") String chain,
+                                                    @Param("addr") String addr,
+                                                    @Param("wt") String wt);
+
+    /** 清理 N 天前的历史信号（SignalCleanupJob 每日调用，分批删除防长事务） */
+    @Modifying
+    @Transactional
+    @Query(value = "DELETE FROM smart_money_signal WHERE signal_time < :before LIMIT 500", nativeQuery = true)
+    int deleteOlderThan(@Param("before") LocalDateTime before);
 }

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -177,6 +177,33 @@ CREATE TABLE IF NOT EXISTS onchain_watch (
     INDEX idx_active  (is_active)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+-- ══════════════════════════════════════════════════════════════════════
+-- 性能优化索引（2026-04）
+-- 执行方式：登录 MySQL 后手动执行，或通过 Flyway/Liquibase 管理
+-- ══════════════════════════════════════════════════════════════════════
+
+-- ── smart_money_signal：findLatest 每 10s 调用 40+ 次，补全复合索引 ──
+--   原有 idx_chain_token(chain_index, token_address) 缺少 wallet_type + signal_time
+--   新索引可覆盖 ORDER BY signal_time DESC LIMIT 1，无需额外排序
+ALTER TABLE smart_money_signal
+    ADD INDEX IF NOT EXISTS idx_chain_token_wt_time (chain_index, token_address, wallet_type, signal_time);
+
+-- ── pump_token：8 个阶段查询均含 received_at < :before AND checked_Xm_at IS NULL ──
+--   无 received_at 索引时全表扫描，表保留 100000 行时压力极大
+ALTER TABLE pump_token
+    ADD INDEX IF NOT EXISTS idx_received_at (received_at),
+    ADD INDEX IF NOT EXISTS idx_status_received (status, received_at);
+
+-- ── four_meme_token：同上 ────────────────────────────────────────────
+ALTER TABLE four_meme_token
+    ADD INDEX IF NOT EXISTS idx_received_at (received_at),
+    ADD INDEX IF NOT EXISTS idx_status_received (status, received_at);
+
+-- ── pump_market_cap_snapshot：findByMintRecent 每次加载 survivors 都调用 ──
+--   当前无索引，随数据增长全表扫描
+ALTER TABLE pump_market_cap_snapshot
+    ADD INDEX IF NOT EXISTS idx_mint_checked_at (mint, checked_at);
+
 -- ── 链上持仓余额快照表 ──────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS onchain_holder_snapshot (
     id             BIGINT AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
## 问题诊断
- smart_money_signal.findRecent 全表扫描（OR + 表达式条件无法走索引）
- smart_money_signal.findLatest 每 10s 调用 40+ 次，索引缺 wallet_type 列
- SignalFetchJob.existsByAddressAndChainIndex 每次最多 40 次 DB 查询
- PriceFetchJob 每 10s 执行 5×SELECT + 5×UPDATE = 10 次 DB 查询
- pump_token/four_meme_token 八阶段查询无 received_at 索引，全表扫描
- pump_market_cap_snapshot 无任何索引且无清理，无限增长
- smart_money_signal 无清理任务，历史数据积压影响所有查询
- perp_funding_rate 保留 5 天，最大可达 90 万行

## 修复内容
### 新增索引（db/schema.sql）
- smart_money_signal: idx_chain_token_wt_time(chain+token+wt+signal_time) 加速 findLatest
- pump_token: idx_received_at + idx_status_received 加速八阶段查询
- four_meme_token: 同上
- pump_market_cap_snapshot: idx_mint_checked_at 加速 findByMintRecent

### 慢 SQL 修复
- SmartMoneySignalRepository.findRecent: 加 7天时间过滤，走 idx_signal_time 范围扫描
- PumpTokenRepository.findSolPrice/findBnbPrice: 去掉无用 ORDER BY（symbol UNIQUE）

### Job 优化
- PriceFetchJob: findAll+saveAll 批量操作，10次DB查询→2次
- SignalFetchJob: ConcurrentHashMap 缓存 wallet 查询结果（TTL 60min），热路径 0次DB查询

### 数据清理
- SignalCleanupJob（新增）: 每天 01:30 清理 signal(30d+) + snapshot(30d+)
- PerpCleanupJob: perp_funding_rate 保留从 5天缩短到 2天（约减少 560,000行）
- SmartMoneySignalRepository: 新增 deleteOlderThan
- PumpMarketCapSnapshotRepository: 新增 deleteOlderThan

https://claude.ai/code/session_01XdraFVEqgmNL9hkTDAA1fV