### PR TITLE
feat: 聚合时间字段可配置（默认 created_at 发现时间）

### DIFF
--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/BinanceSquareTokenStatRepository.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/repository/BinanceSquareTokenStatRepository.java
@@ -31,6 +31,24 @@ public interface BinanceSquareTokenStatRepository extends JpaRepository<BinanceS
     List<Object[]> aggregateSince(@Param("since") LocalDateTime since,
                                   @Param("limit") int limit);
 
+    /**
+     * 按「我们首次抓到帖子时间」聚合（= 发现时间，对推荐 feed 更直观）。
+     */
+    @Query(value = "SELECT token, " +
+            "       COALESCE(SUM(score),0)    AS score_sum, " +
+            "       COALESCE(SUM(likes),0)    AS likes_sum, " +
+            "       COALESCE(SUM(comments),0) AS comments_sum, " +
+            "       COUNT(*)                  AS post_count, " +
+            "       MAX(in_binance)           AS in_binance " +
+            "FROM binance_square_token_stat " +
+            "WHERE created_at >= :since " +
+            "GROUP BY token " +
+            "ORDER BY score_sum DESC " +
+            "LIMIT :limit",
+            nativeQuery = true)
+    List<Object[]> aggregateSinceByCreatedAt(@Param("since") LocalDateTime since,
+                                             @Param("limit") int limit);
+
     @Modifying
     @Transactional
     @Query(value = "DELETE FROM binance_square_token_stat WHERE post_date < :cutoff LIMIT 500",

--- a/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/BinanceSquareService.java
+++ b/dashboard/src/main/java/com/deanrobin/aios/dashboard/service/BinanceSquareService.java
@@ -5,6 +5,7 @@ import com.deanrobin.aios.dashboard.repository.BinanceSquareRankSnapshotReposito
 import com.deanrobin.aios.dashboard.repository.BinanceSquareTokenStatRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -26,10 +27,20 @@ public class BinanceSquareService {
     private final BinanceSquareTokenStatRepository    tokenStatRepo;
     private final BinanceSquareRankSnapshotRepository snapshotRepo;
 
+    /**
+     * 聚合时的时间字段：
+     *   post_date   = 帖子原始发布时间（Python v5 行为）
+     *   created_at  = 我们首次抓到该帖子的时间（对推荐 feed 更实时）
+     */
+    @Value("${binance-square.aggregate-by:created_at}")
+    private String aggregateBy;
+
     /** 最近 N 小时 TopN 热度榜。 */
     public List<Map<String, Object>> topTokensSince(int hours, int limit) {
         LocalDateTime since = LocalDateTime.now().minusHours(hours);
-        List<Object[]> rows = tokenStatRepo.aggregateSince(since, limit);
+        List<Object[]> rows = "post_date".equalsIgnoreCase(aggregateBy)
+                ? tokenStatRepo.aggregateSince(since, limit)
+                : tokenStatRepo.aggregateSinceByCreatedAt(since, limit);
         List<Map<String, Object>> out = new ArrayList<>(rows.size());
         for (Object[] r : rows) {
             Map<String, Object> m = new LinkedHashMap<>();

--- a/dashboard/src/main/resources/application.yml
+++ b/dashboard/src/main/resources/application.yml
@@ -70,6 +70,8 @@ binance-square:
   feed-url: ${BINANCE_SQUARE_FEED_URL:https://www.binance.com/bapi/composite/v9/friendly/pgc/feed/feed-recommend/list}
   # 独立飞书 webhook（POST JSON）
   alert-url: ${BINANCE_SQUARE_ALERT_URL:https://open.feishu.cn/open-apis/bot/v2/hook/c035c556-dcf4-4145-a4e8-a7a956bbce96}
+  # 聚合时间字段：created_at=发现时间（推荐 feed 更实时，默认）；post_date=帖子原始发布时间（与 Python v5 对齐）
+  aggregate-by: ${BINANCE_SQUARE_AGGREGATE_BY:created_at}
 
 # ── 链上持仓监控 RPC 配置 ─────────────────────────────────────────
 onchain:

--- a/dashboard/src/main/resources/templates/binance-square.html
+++ b/dashboard/src/main/resources/templates/binance-square.html
@@ -3,148 +3,313 @@
       th:replace="~{layout :: page('币安广场热度', ~{::main})}">
 <body><main>
 
-<div class="d-flex align-items-center flex-wrap gap-3 mb-3">
-    <span class="pulse-dot"></span>
-    <h5 class="fw-7 mb-0 ms-1">币安广场代币热度榜</h5>
+<style>
+    /* ── 页头 ─────────────────────────────────────── */
+    .sq-hero {
+        display: flex; align-items: center; justify-content: space-between;
+        flex-wrap: wrap; gap: 14px; margin-bottom: 18px;
+    }
+    .sq-title {
+        display: flex; align-items: center; gap: 10px;
+    }
+    .sq-title h5 { margin: 0; font-weight: 800; letter-spacing: -.2px; }
+    .sq-title .subtitle { color: var(--t3); font-size: .78rem; margin-top: 2px; }
 
-    <div class="tab-row" style="background:#f8faff">
-        <a th:href="@{/binance-square(hours=1)}"
-           class="tab-item"
-           th:classappend="${hours==1?' active':''}"
-           style="font-size:.8rem;text-decoration:none">近 1 小时</a>
-        <a th:href="@{/binance-square(hours=8)}"
-           class="tab-item"
-           th:classappend="${hours==8?' active':''}"
-           style="font-size:.8rem;text-decoration:none">近 8 小时</a>
-        <a th:href="@{/binance-square(hours=24)}"
-           class="tab-item"
-           th:classappend="${hours==24?' active':''}"
-           style="font-size:.8rem;text-decoration:none">近 24 小时</a>
+    .sq-meta {
+        display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+    }
+
+    /* ── 概览卡片 ─────────────────────────────────── */
+    .sq-summary {
+        display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;
+        margin-bottom: 18px;
+    }
+    @media (max-width: 900px) { .sq-summary { grid-template-columns: repeat(2, 1fr); } }
+
+    /* ── 表格：自定义更紧凑的行高 ──────────────────── */
+    .sq-table thead th {
+        font-size: .66rem; padding: 11px 14px;
+    }
+    .sq-table tbody td { padding: 14px; vertical-align: middle; }
+
+    /* 排名徽章：TOP3 金/银/铜，其他浅灰 */
+    .rank-badge {
+        display: inline-flex; align-items: center; justify-content: center;
+        width: 28px; height: 28px; border-radius: 8px;
+        font-family: 'SF Mono','Menlo','Monaco','Courier New',monospace;
+        font-size: .82rem; font-weight: 800; color: var(--t2);
+        background: rgba(118,118,128,0.12);
+    }
+    .rank-badge.r1 { background: linear-gradient(135deg,#ffd54a,#ffb300); color:#8a5a00; box-shadow: 0 2px 6px rgba(255,179,0,.32); }
+    .rank-badge.r2 { background: linear-gradient(135deg,#e5e7eb,#b8bcc3); color:#43474d; box-shadow: 0 2px 6px rgba(170,170,170,.28); }
+    .rank-badge.r3 { background: linear-gradient(135deg,#e6b38c,#b07547); color:#5a3210; box-shadow: 0 2px 6px rgba(176,117,71,.30); }
+
+    /* Token avatar（颜色按首字母散列） */
+    .tk-cell { display: flex; align-items: center; gap: 10px; min-width: 0; }
+    .tk-avatar {
+        flex: 0 0 auto; width: 34px; height: 34px; border-radius: 50%;
+        display: inline-flex; align-items: center; justify-content: center;
+        color: #fff; font-weight: 800; font-size: .82rem; letter-spacing: -.2px;
+        font-family: -apple-system,'SF Pro Display',sans-serif;
+        box-shadow: inset 0 0 0 1px rgba(255,255,255,.25), 0 1px 3px rgba(0,0,0,.14);
+    }
+    .tk-meta { display: flex; flex-direction: column; min-width: 0; }
+    .tk-sym  { font-weight: 700; font-size: .96rem; letter-spacing: -.2px; line-height: 1.15; }
+    .tk-sub  { font-size: .7rem; color: var(--t3); margin-top: 1px; }
+
+    /* 分数：数字 + 迷你进度条 */
+    .score-wrap { display: flex; flex-direction: column; gap: 6px; min-width: 90px; }
+    .score-num  {
+        font-family: 'SF Mono','Menlo','Monaco','Courier New',monospace;
+        font-size: .92rem; font-weight: 800; color: var(--blue); letter-spacing: -.2px;
+    }
+    .score-bar  { height: 4px; background: rgba(118,118,128,0.12); border-radius: 999px; overflow: hidden; }
+    .score-bar-fill {
+        height: 100%; border-radius: 999px;
+        background: linear-gradient(90deg, #5AC8FA, #007AFF);
+    }
+
+    /* 互动信息组合 */
+    .eng {
+        display: inline-flex; align-items: center; gap: 10px;
+        font-family: 'SF Mono','Menlo','Monaco','Courier New',monospace;
+        font-size: .78rem; color: var(--t2);
+    }
+    .eng span { display: inline-flex; align-items: center; gap: 3px; white-space: nowrap; }
+    .eng em   { font-style: normal; color: var(--t3); font-size: .9em; }
+
+    /* 升降：大一号的徽章 */
+    .delta {
+        display: inline-flex; align-items: center; justify-content: center;
+        min-width: 46px; padding: 3px 9px; border-radius: 8px;
+        font-family: 'SF Mono','Menlo','Monaco','Courier New',monospace;
+        font-size: .78rem; font-weight: 700; white-space: nowrap;
+    }
+    .delta.up   { background: var(--green-l);  color: var(--green);  }
+    .delta.dn   { background: var(--red-l);    color: var(--red);    }
+    .delta.new  { background: var(--blue-l);   color: var(--blue);   }
+    .delta.flat { background: rgba(118,118,128,0.12); color: var(--t2); }
+    .delta.none { background: transparent; color: var(--t3); }
+
+    /* 上架徽章 */
+    .listed {
+        display: inline-flex; align-items: center; gap: 4px;
+        padding: 3px 10px; border-radius: 999px;
+        font-size: .72rem; font-weight: 700; letter-spacing: .2px;
+    }
+    .listed.yes { background: var(--green-l); color: var(--green); }
+    .listed.no  { background: rgba(118,118,128,0.12); color: var(--t3); font-weight: 500; }
+
+    /* 移动端：隐藏次要列 */
+    @media (max-width: 720px) {
+        .sq-table .col-engagement,
+        .sq-table .col-posts      { display: none; }
+        .score-wrap { min-width: 64px; }
+    }
+</style>
+
+<!-- ── 页头 ─────────────────────────────────────────── -->
+<div class="sq-hero">
+    <div class="sq-title">
+        <span class="pulse-dot"></span>
+        <div>
+            <h5>🔥 币安广场代币热度榜</h5>
+            <div class="subtitle">基于广场帖子聚合，分数 = 曝光 + 👍 + 💬 的加权和</div>
+        </div>
     </div>
-
-    <span id="auto-badge"
-          style="background:#f0f4ff;border:1px solid #c7d7fa;color:#3b82f6;
-                 border-radius:20px;padding:3px 12px;font-size:.76rem;font-weight:600;
-                 pointer-events:none;user-select:none">
-        🔄 <span id="auto-countdown">30</span>s
-    </span>
+    <div class="sq-meta">
+        <div class="tab-row" style="background:rgba(118,118,128,0.12)">
+            <a th:href="@{/binance-square(hours=1)}"  class="tab-item" th:classappend="${hours==1?' active':''}"  style="text-decoration:none">近 1 小时</a>
+            <a th:href="@{/binance-square(hours=8)}"  class="tab-item" th:classappend="${hours==8?' active':''}"  style="text-decoration:none">近 8 小时</a>
+            <a th:href="@{/binance-square(hours=24)}" class="tab-item" th:classappend="${hours==24?' active':''}" style="text-decoration:none">近 24 小时</a>
+        </div>
+        <span class="info-pill">📊 Top <span th:text="${top.size()}">0</span></span>
+        <span class="info-pill">🕐 <span id="last-update-time">—</span></span>
+        <span class="info-pill" id="auto-badge" style="color:var(--blue);background:var(--blue-l)">🔄 <span id="auto-countdown">30</span>s</span>
+    </div>
 </div>
 
-<div class="d-flex gap-2 mb-3" style="flex-wrap:wrap">
-    <span class="tag-gray">窗口 <span th:text="${hours}"></span> 小时</span>
-    <span class="tag-gray">最后更新 <span id="last-update-time">—</span></span>
-    <span class="tag-gray">✅ 币安已上架 &nbsp; ❓ 待验证</span>
-</div>
+<!-- ── 概览卡片 ─────────────────────────────────────── -->
+<div class="sq-summary" id="sq-summary"></div>
 
+<!-- ── 榜单 ─────────────────────────────────────────── -->
 <div class="card">
     <div class="card-body p-0">
         <div th:if="${top.isEmpty()}" class="empty-state">
-            <div class="ei">📭</div><div>暂无数据（Job 每 5 分钟抓一次，刚启动请稍等）</div>
+            <div class="ei">📭</div>
+            <div>暂无数据（Job 每 5 分钟抓一次，刚启动请稍等）</div>
         </div>
-        <table th:unless="${top.isEmpty()}" class="table" id="sq-tbl">
-            <thead><tr>
-                <th style="width:60px">#</th>
-                <th style="width:80px">升/降</th>
-                <th>代币</th>
-                <th>分数</th>
-                <th>👍 点赞</th>
-                <th>💬 评论</th>
-                <th>帖子数</th>
-                <th>币安</th>
-            </tr></thead>
-            <tbody id="sq-tbody">
-            <tr th:each="row,iter : ${top}"
-                th:class="${iter.index==0?'rank-1':(iter.index==1?'rank-2':(iter.index==2?'rank-3':''))}">
-                <td class="mono fw-7 t-dim" th:text="${iter.index + 1}"></td>
-                <td class="mono">
-                    <span th:if="${!row.hasSnapshot}" class="tag-gray">—</span>
-                    <span th:if="${row.hasSnapshot and row.rankDelta == null}"
-                          class="tag-up" style="background:#eaf4ff;color:#2563eb">NEW</span>
-                    <span th:if="${row.rankDelta != null and row.rankDelta &gt; 0}"
-                          class="tag-up" th:text="'▲' + ${row.rankDelta}"></span>
-                    <span th:if="${row.rankDelta != null and row.rankDelta &lt; 0}"
-                          class="tag-dn" th:text="'▼' + ${-row.rankDelta}"></span>
-                    <span th:if="${row.rankDelta != null and row.rankDelta == 0}"
-                          class="tag-gray">持平</span>
-                </td>
-                <td>
-                    <span class="fw-7" style="font-size:.92rem" th:text="${row.token}"></span>
-                </td>
-                <td class="mono fw-7 t-blue" th:text="${row.score}"></td>
-                <td class="mono" th:text="${row.likes}"></td>
-                <td class="mono" th:text="${row.comments}"></td>
-                <td class="mono" th:text="${row.postCount}"></td>
-                <td>
-                    <span th:if="${row.inBinance}" class="tag-up">✅</span>
-                    <span th:unless="${row.inBinance}" class="tag-gray">❓</span>
-                </td>
-            </tr>
-            </tbody>
-        </table>
+        <div th:unless="${top.isEmpty()}" class="table-responsive">
+            <table class="table sq-table" id="sq-tbl">
+                <thead>
+                <tr>
+                    <th style="width:52px">#</th>
+                    <th style="width:78px">升/降</th>
+                    <th>代币</th>
+                    <th style="width:150px">热度分数</th>
+                    <th class="col-engagement">互动</th>
+                    <th class="col-posts" style="width:80px">帖子数</th>
+                    <th style="width:96px">币安</th>
+                </tr>
+                </thead>
+                <tbody id="sq-tbody"></tbody>
+            </table>
+        </div>
     </div>
 </div>
 
-<script>
-const HOURS = /*[[${hours}]]*/ 1;
+<script th:inline="javascript">
+const HOURS       = /*[[${hours}]]*/ 1;
+const INIT_ROWS   = /*[[${top}]]*/ [];
 
-function updateLastTime() {
-    document.getElementById('last-update-time').textContent =
-        new Date().toLocaleString('zh-CN', {
-            timeZone: 'Asia/Shanghai', hour:'2-digit', minute:'2-digit', second:'2-digit'
-        });
+/* ── 工具 ──────────────────────────────────────────── */
+function escapeHtml(s){
+    return String(s||'').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+}
+function fmtNum(v){
+    const n = Number(v)||0, a = Math.abs(n);
+    if (a >= 1e6) return (n/1e6).toFixed(1) + 'M';
+    if (a >= 1e3) return (n/1e3).toFixed(1) + 'K';
+    return String(n);
+}
+/* 根据首字母散列颜色（Apple 系色盘） */
+const AVATAR_COLORS = [
+    '#007AFF','#34C759','#FF9500','#AF52DE','#FF2D55',
+    '#5AC8FA','#FF3B30','#5856D6','#FF9F0A','#30B0C7'
+];
+function avatarColor(sym){
+    const s = String(sym||'?');
+    let h = 0;
+    for (let i=0; i<s.length; i++) h = (h*31 + s.charCodeAt(i)) >>> 0;
+    return AVATAR_COLORS[h % AVATAR_COLORS.length];
+}
+function firstChar(sym){
+    const s = String(sym||'?').trim();
+    return s ? s.charAt(0).toUpperCase() : '?';
 }
 
-async function refresh() {
+function renderDelta(d){
+    if (!d.hasSnapshot)                return '<span class="delta none">—</span>';
+    if (d.rankDelta == null)           return '<span class="delta new">NEW</span>';
+    if (d.rankDelta > 0)               return `<span class="delta up">▲ ${d.rankDelta}</span>`;
+    if (d.rankDelta < 0)               return `<span class="delta dn">▼ ${-d.rankDelta}</span>`;
+    return '<span class="delta flat">持平</span>';
+}
+function renderListed(yes){
+    return yes
+        ? '<span class="listed yes">✅ 已上架</span>'
+        : '<span class="listed no">未上架</span>';
+}
+
+function renderRows(rows){
+    const tbody = document.getElementById('sq-tbody');
+    if (!tbody) return;
+    if (!rows || !rows.length) { tbody.innerHTML = ''; return; }
+    const topScore = Math.max(1, ...rows.map(r => Number(r.score)||0));
+
+    tbody.innerHTML = rows.map((d, i) => {
+        const rank = i + 1;
+        const rankCls = rank === 1 ? 'r1' : rank === 2 ? 'r2' : rank === 3 ? 'r3' : '';
+        const rowHi   = rank === 1 ? 'rank-1' : rank === 2 ? 'rank-2' : rank === 3 ? 'rank-3' : '';
+        const pct     = Math.max(4, Math.round((Number(d.score)||0) * 100 / topScore));
+        const sym     = escapeHtml(d.token);
+        const color   = avatarColor(d.token);
+
+        return `<tr class="${rowHi}">
+            <td><span class="rank-badge ${rankCls}">${rank}</span></td>
+            <td>${renderDelta(d)}</td>
+            <td>
+                <div class="tk-cell">
+                    <span class="tk-avatar" style="background:${color}">${escapeHtml(firstChar(d.token))}</span>
+                    <div class="tk-meta">
+                        <span class="tk-sym">${sym}</span>
+                        <span class="tk-sub">${d.inBinance ? '币安已上架' : '链上代币'}</span>
+                    </div>
+                </div>
+            </td>
+            <td>
+                <div class="score-wrap">
+                    <span class="score-num">${fmtNum(d.score)}</span>
+                    <div class="score-bar"><div class="score-bar-fill" style="width:${pct}%"></div></div>
+                </div>
+            </td>
+            <td class="col-engagement">
+                <span class="eng">
+                    <span>👍 <em>${fmtNum(d.likes)}</em></span>
+                    <span>💬 <em>${fmtNum(d.comments)}</em></span>
+                </span>
+            </td>
+            <td class="col-posts mono">${fmtNum(d.postCount)}</td>
+            <td>${renderListed(d.inBinance)}</td>
+        </tr>`;
+    }).join('');
+}
+
+/* ── 概览卡片 ──────────────────────────────────────── */
+function renderSummary(rows){
+    const box = document.getElementById('sq-summary');
+    if (!box) return;
+    if (!rows || !rows.length) { box.innerHTML = ''; return; }
+
+    const total     = rows.length;
+    const top1      = rows[0];
+    const listed    = rows.filter(r => r.inBinance).length;
+
+    let biggestUp = null, biggestDn = null;
+    rows.forEach((r,i) => {
+        if (r.rankDelta == null) return;
+        if (r.rankDelta > 0 && (!biggestUp || r.rankDelta > biggestUp.rankDelta)) biggestUp = {...r, currRank: i+1};
+        if (r.rankDelta < 0 && (!biggestDn || r.rankDelta < biggestDn.rankDelta)) biggestDn = {...r, currRank: i+1};
+    });
+
+    const cards = [
+        {cls:'sc-orange', icon:'🔥', val: escapeHtml(top1.token),
+         lbl:'当前榜首', sub:`分数 ${fmtNum(top1.score)} · ${top1.postCount} 帖`},
+        {cls:'sc-blue',   icon:'📊', val: total + '',
+         lbl:'上榜代币', sub:`币安已上架 ${listed} 个`},
+        {cls:'sc-green',  icon:'📈', val: biggestUp ? escapeHtml(biggestUp.token) : '—',
+         lbl:'最大升幅', sub: biggestUp ? `▲ ${biggestUp.rankDelta} 名 · 现 #${biggestUp.currRank}` : '暂无'},
+        {cls:'sc-red',    icon:'📉', val: biggestDn ? escapeHtml(biggestDn.token) : '—',
+         lbl:'最大跌幅', sub: biggestDn ? `▼ ${-biggestDn.rankDelta} 名 · 现 #${biggestDn.currRank}` : '暂无'},
+    ];
+    box.innerHTML = cards.map(c => `
+        <div class="stat-card ${c.cls}">
+            <span class="sc-icon">${c.icon}</span>
+            <div class="sc-val" style="font-size:1.25rem;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${c.val}</div>
+            <div class="sc-lbl">${c.lbl}</div>
+            <div class="sc-sub">${c.sub}</div>
+        </div>`).join('');
+}
+
+/* ── 刷新 ──────────────────────────────────────────── */
+function updateLastTime(){
+    document.getElementById('last-update-time').textContent =
+        new Date().toLocaleTimeString('zh-CN', {
+            timeZone:'Asia/Shanghai', hour:'2-digit', minute:'2-digit', second:'2-digit'
+        });
+}
+async function refresh(){
     try {
         const r = await fetch(`/api/binance-square/top?hours=${HOURS}&limit=20`);
         const rows = await r.json();
-        const tbody = document.getElementById('sq-tbody');
-        if (!tbody) return;
         if (!rows || !rows.length) return;
-        tbody.innerHTML = rows.map((d, i) => {
-            const rankCls = i===0 ? 'rank-1' : i===1 ? 'rank-2' : i===2 ? 'rank-3' : '';
-            const binance = d.inBinance
-                ? '<span class="tag-up">✅</span>'
-                : '<span class="tag-gray">❓</span>';
-            let delta;
-            if (!d.hasSnapshot) {
-                delta = '<span class="tag-gray">—</span>';
-            } else if (d.rankDelta == null) {
-                delta = '<span class="tag-up" style="background:#eaf4ff;color:#2563eb">NEW</span>';
-            } else if (d.rankDelta > 0) {
-                delta = `<span class="tag-up">▲${d.rankDelta}</span>`;
-            } else if (d.rankDelta < 0) {
-                delta = `<span class="tag-dn">▼${-d.rankDelta}</span>`;
-            } else {
-                delta = '<span class="tag-gray">持平</span>';
-            }
-            return `<tr class="${rankCls}">
-                <td class="mono fw-7 t-dim">${i+1}</td>
-                <td class="mono">${delta}</td>
-                <td><span class="fw-7" style="font-size:.92rem">${escapeHtml(d.token)}</span></td>
-                <td class="mono fw-7 t-blue">${d.score}</td>
-                <td class="mono">${d.likes}</td>
-                <td class="mono">${d.comments}</td>
-                <td class="mono">${d.postCount}</td>
-                <td>${binance}</td>
-            </tr>`;
-        }).join('');
+        renderRows(rows);
+        renderSummary(rows);
         updateLastTime();
     } catch(e) { console.warn('refresh binance-square', e); }
 }
 
-function escapeHtml(s) {
-    return String(s||'').replace(/[&<>"']/g, c => ({
-        '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
-}
-
+/* 首屏：先用 SSR 数据渲染（JS 版本能做进度条 + 头像） */
+renderRows(INIT_ROWS);
+renderSummary(INIT_ROWS);
 updateLastTime();
+
 let countdown = 30;
 const countEl = document.getElementById('auto-countdown');
 setInterval(() => {
     countdown--;
     if (countdown <= 0) { countdown = 30; refresh(); }
-    countEl.textContent = countdown;
+    if (countEl) countEl.textContent = countdown;
 }, 1000);
 </script>
 


### PR DESCRIPTION
- 新增 binance-square.aggregate-by 配置，可选 created_at / post_date
- 默认 created_at：推荐 feed 非时间序，按「我们首次抓到」聚合 更贴合实时榜单语义，1h / 8h 立即有数据
- 保留 post_date 聚合兼容 Python v5 原版行为